### PR TITLE
Publish LinuxArm64 builds

### DIFF
--- a/.teamcity/src/subprojects/release/publishing/PublishMavenBuilds.kt
+++ b/.teamcity/src/subprojects/release/publishing/PublishMavenBuilds.kt
@@ -106,6 +106,7 @@ object PublishLinuxNativeToMaven : BuildType({
         createSonatypeRepository("Linux")
         publish(
             "publishLinuxX64PublicationToMavenRepository",
+            "publishLinuxArm64PublicationToMavenRepository",
             gradleParams = "--parallel -Psigning.gnupg.homeDir=%env.SIGN_KEY_LOCATION%/.gnupg"
         )
     }


### PR DESCRIPTION
AFAIK we can't test them without test infrastructure, like all other kotlinx projects don't test the linuxArm artifacts too.

@e5l Follow up of https://github.com/ktorio/ktor/pull/3587