### PR TITLE
Add retry trigger for builds

### DIFF
--- a/.teamcity/src/subprojects/build/core/ProjectCore.kt
+++ b/.teamcity/src/subprojects/build/core/ProjectCore.kt
@@ -68,6 +68,10 @@ fun BuildType.createCompositeBuild(
     triggers {
         if (withTrigger) {
             onChangeAllBranchesTrigger()
+            retryBuild {
+                attempts = 1
+                delaySeconds = 60
+            }
         }
     }
     dependencies {


### PR DESCRIPTION
I'm noticing that we have frequent random build failures from flaky tests, so I thought we could introduce a single retry here instead of having to manually retry on most PRs.  This kinda hides the problem with the tests though, but it'll be a struggle to fix them all with the different platforms, etc.