### PR TITLE
Fix for 2.* JS publishing builds failing due to WASM inclusion

### DIFF
--- a/.teamcity/src/subprojects/eap/PublishSpaceBuilds.kt
+++ b/.teamcity/src/subprojects/eap/PublishSpaceBuilds.kt
@@ -65,12 +65,8 @@ object PublishJSToSpace : BuildType({
         root(VCSCoreEAP)
     }
     steps {
-        releaseToSpace(
-            listOf(
-                "publishJsPublicationToMavenRepository",
-                "publishWasmJsPublicationToMavenRepository"
-            )
-        )
+        releaseToSpace(listOf("publishJsPublicationToMavenRepository"))
+        releaseToSpace(listOf("publishWasmJsPublicationToMavenRepository"), optional = true)
     }
     params {
         param("eapVersion", SetBuildNumber.depParamRefs.buildNumber.ref)
@@ -186,12 +182,19 @@ object PublishMacOSNativeToSpace : BuildType({
     }
 })
 
-private fun BuildSteps.releaseToSpace(gradleTasks: List<String>, gradleParams: String = "", os: String = "Linux") {
+private fun BuildSteps.releaseToSpace(
+    gradleTasks: List<String>,
+    gradleParams: String = "",
+    os: String = "Linux",
+    optional: Boolean = false,
+) {
     gradle {
         name = "Publish"
         tasks =
             "${gradleTasks.joinToString(" ")} --i -PeapVersion=%eapVersion% $gradleParams --stacktrace --parallel -Porg.gradle.internal.network.retry.max.attempts=100000"
         jdkHome = "%env.${java11.env}%"
         buildFile = "build.gradle.kts"
+        if (optional)
+            executionMode = BuildStep.ExecutionMode.ALWAYS
     }
 }

--- a/.teamcity/src/subprojects/release/space/PublishSpaceBuildsRelease.kt
+++ b/.teamcity/src/subprojects/release/space/PublishSpaceBuildsRelease.kt
@@ -67,7 +67,11 @@ object PublishJSToSpaceRelease : BuildType({
     }
     steps {
         releaseToSpace(
-            listOf("publishJsPublicationToMavenRepository", "publishWasmJsPublicationToMavenRepository"),
+            listOf("publishJsPublicationToMavenRepository"),
+            gradleParams = "-Psigning.gnupg.homeDir=%env.SIGN_KEY_LOCATION%/.gnupg"
+        )
+        releaseToSpace(
+            listOf("publishWasmJsPublicationToMavenRepository"),
             gradleParams = "-Psigning.gnupg.homeDir=%env.SIGN_KEY_LOCATION%/.gnupg"
         )
     }
@@ -176,6 +180,7 @@ private fun BuildSteps.releaseToSpace(
     gradleTasks: List<String>,
     gradleParams: String = "",
     os: String = "",
+    optional: Boolean = false,
 ) {
     prepareKeyFile(os)
     gradle {
@@ -184,6 +189,8 @@ private fun BuildSteps.releaseToSpace(
             "${gradleTasks.joinToString(" ")} --i -PreleaseVersion=$releaseVersion $gradleParams --stacktrace --no-parallel -Porg.gradle.internal.network.retry.max.attempts=100000"
         jdkHome = "%env.${java11.env}%"
         buildFile = "build.gradle.kts"
+        if (optional)
+            executionMode = BuildStep.ExecutionMode.ALWAYS
     }
     cleanupKeyFile(os)
 }


### PR DESCRIPTION
Looks like the new WASM target is interfering with builds < 3.0.  This change will just split up the two targets and make the WASM one optional for now.  Eventually we can remove this distinction or maybe use build parameters to control it.