### PR TITLE
Add upload of generator site for testing

### DIFF
--- a/.teamcity/src/subprojects/build/generator/BuildGeneratorWebsite.kt
+++ b/.teamcity/src/subprojects/build/generator/BuildGeneratorWebsite.kt
@@ -1,0 +1,70 @@
+package subprojects.build.generator
+
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.nodeJS
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import subprojects.VCSKtorGeneratorWebsite
+
+object BuildGeneratorWebsite : BuildType({
+    id("KtorGeneratorWebsite_Test")
+    name = "Build generator website"
+
+    vcs {
+        root(VCSKtorGeneratorWebsite)
+    }
+
+    steps {
+        nodeJS {
+            name = "Node.js test + build"
+            shellScript = """
+                npm ci
+                npm run lint
+                npm build
+            """.trimIndent()
+        }
+        script {
+            name = "Upload website archive to Space"
+            scriptContent = """
+               tar -zcvf website.tar.gz -C build .
+               curl -i \
+                  -H "Authorization: Bearer %env.PUBLISHING_TOKEN%" \
+                  https://packages.jetbrains.team/files/p/ktor/files/ktor-generator-website/test/ \
+                  --upload-file website.tar.gz
+            """.trimIndent()
+        }
+    }
+
+    features {
+        pullRequests {
+            vcsRootExtId = VCSKtorGeneratorWebsite.id.toString()
+            provider = github {
+                authType = token {
+                    token = "%github.token%"
+                }
+                filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
+            }
+        }
+        commitStatusPublisher {
+            vcsRootExtId = VCSKtorGeneratorWebsite.id.toString()
+
+            publisher = github {
+                githubUrl = "https://api.github.com"
+                authType = personalToken {
+                    token = "%github.token%"
+                }
+            }
+        }
+    }
+
+    triggers {
+        vcs {
+            branchFilter = """
+                +:refs/pull/*
+            """.trimIndent()
+        }
+    }
+})

--- a/.teamcity/src/subprojects/build/generator/BuildGeneratorWebsite.kt
+++ b/.teamcity/src/subprojects/build/generator/BuildGeneratorWebsite.kt
@@ -12,6 +12,9 @@ import subprojects.VCSKtorGeneratorWebsite
 object BuildGeneratorWebsite : BuildType({
     id("KtorGeneratorWebsite_Test")
     name = "Build generator website"
+    params {
+        password("env.PUBLISHING_TOKEN", value = "%space.packages.publish.token%")
+    }
 
     vcs {
         root(VCSKtorGeneratorWebsite)
@@ -23,11 +26,11 @@ object BuildGeneratorWebsite : BuildType({
             shellScript = """
                 npm ci
                 npm run lint
-                npm build
+                npm run build --verbose
             """.trimIndent()
         }
         script {
-            name = "Upload website archive to Space"
+            name = "Upload test archive to Space"
             scriptContent = """
                tar -zcvf website.tar.gz -C build .
                curl -i \

--- a/.teamcity/src/subprojects/build/generator/ProjectGenerator.kt
+++ b/.teamcity/src/subprojects/build/generator/ProjectGenerator.kt
@@ -1,191 +1,27 @@
 package subprojects.build.generator
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.nodeJS
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
-import subprojects.VCSKtorGeneratorBackend
-import subprojects.VCSKtorGeneratorWebsite
-import subprojects.VCSPluginRegistry
 
 object ProjectGenerator : Project({
     id("ProjectKtorGenerator")
     name = "Project Generator"
     description = "Code for start.ktor.io"
-    params {
-        password("env.PUBLISHING_TOKEN", value = "%space.packages.publish.token%")
-    }
 
-    buildType {
-        id("KtorPluginRegistry")
-        name = "Publish plugin registry"
-        vcs {
-            root(VCSPluginRegistry)
-        }
+    /**
+     *
+     */
+    buildType(PublishPluginRegistry)
 
-        steps {
-            gradle {
-                name = "Build plugin registry"
-                tasks = "packageRegistry"
-                buildFile = "build.gradle.kts"
-                jdkHome = "%env.JDK_11%"
-            }
-            script {
-                name = "Push registry archive to Space"
-                scriptContent = """
-                    curl -i \
-                      -H "Authorization: Bearer %env.PUBLISHING_TOKEN%" \
-                      https://packages.jetbrains.team/files/p/ktor/files/plugin-registry/ \
-                      --upload-file build/distributions/registry.tar.gz
-                """
-            }
-        }
+    /**
+     * Tests registry, and ensures any new plugins can be built.
+     */
+    buildType(TestPluginRegistry)
 
-        triggers {
-            vcs {
-                branchFilter = "+:<default>"
-            }
-        }
-    }
-
-    buildType {
-        id("KtorPluginRegistryVerify")
-        name = "Test plugin registry"
-        vcs {
-            root(VCSPluginRegistry)
-        }
-
-        steps {
-            gradle {
-                name = "Test plugin registry"
-                tasks = "resolvePlugins detekt test buildRegistry"
-                buildFile = "build.gradle.kts"
-                jdkHome = "%env.JDK_11%"
-            }
-        }
-
-        features {
-            pullRequests {
-                vcsRootExtId = VCSPluginRegistry.id.toString()
-                provider = github {
-                    authType = token {
-                        token = "%github.token%"
-                    }
-                    filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
-                }
-            }
-            commitStatusPublisher {
-                vcsRootExtId = VCSPluginRegistry.id.toString()
-
-                publisher = github {
-                    githubUrl = "https://api.github.com"
-                    authType = personalToken {
-                        token = "%github.token%"
-                    }
-                }
-            }
-        }
-
-        triggers {
-            vcs {}
-        }
-    }
-
-    buildType {
-        id("KtorGeneratorBackendVerify")
-        name = "Test generator backend"
-        params {
-            password("env.SPACE_USERNAME", value = "%space.packages.apl.user%")
-            password("env.SPACE_PASSWORD", value = "%space.packages.apl.token%")
-        }
-        vcs {
-            root(VCSKtorGeneratorBackend)
-        }
-
-        steps {
-            gradle {
-                name = "Test generator backend"
-                tasks = "test"
-                buildFile = "build.gradle.kts"
-                jdkHome = "%env.JDK_11%"
-            }
-        }
-
-        features {
-            pullRequests {
-                vcsRootExtId = VCSKtorGeneratorBackend.id.toString()
-                provider = github {
-                    authType = token {
-                        token = "%github.token%"
-                    }
-                    filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
-                }
-            }
-            commitStatusPublisher {
-                vcsRootExtId = VCSKtorGeneratorBackend.id.toString()
-
-                publisher = github {
-                    githubUrl = "https://api.github.com"
-                    authType = personalToken {
-                        token = "%github.token%"
-                    }
-                }
-            }
-        }
-
-        triggers {
-            vcs {}
-        }
-    }
-
-    buildType {
-        id("KtorGeneratorWebsite_Test")
-        name = "Test generator website"
-
-        vcs {
-            root(VCSKtorGeneratorWebsite)
-        }
-
-        steps {
-            nodeJS {
-                name = "Node.js test"
-                shellScript = """
-                    npm install
-                    npm ci
-                    npm run lint
-                """.trimIndent()
-            }
-        }
-
-        features {
-            pullRequests {
-                vcsRootExtId = VCSKtorGeneratorWebsite.id.toString()
-                provider = github {
-                    authType = token {
-                        token = "%github.token%"
-                    }
-                    filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
-                }
-            }
-            commitStatusPublisher {
-                vcsRootExtId = VCSKtorGeneratorWebsite.id.toString()
-
-                publisher = github {
-                    githubUrl = "https://api.github.com"
-                    authType = personalToken {
-                        token = "%github.token%"
-                    }
-                }
-            }
-        }
-
-        triggers {
-            vcs {}
-        }
-    }
+    /**
+     * Runs on every PR for ktor-generator-website.
+     */
+    buildType(BuildGeneratorWebsite)
 
 })
+
+

--- a/.teamcity/src/subprojects/build/generator/PublishPluginRegistry.kt
+++ b/.teamcity/src/subprojects/build/generator/PublishPluginRegistry.kt
@@ -1,0 +1,42 @@
+package subprojects.build.generator
+
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import subprojects.VCSPluginRegistry
+
+object PublishPluginRegistry : BuildType({
+    id("KtorPluginRegistry")
+    name = "Publish plugin registry"
+    vcs {
+        root(VCSPluginRegistry)
+    }
+    params {
+        password("env.PUBLISHING_TOKEN", value = "%space.packages.publish.token%")
+    }
+
+    steps {
+        gradle {
+            name = "Build plugin registry"
+            tasks = "packageRegistry"
+            buildFile = "build.gradle.kts"
+            jdkHome = "%env.JDK_11%"
+        }
+        script {
+            name = "Upload registry archive to Space"
+            scriptContent = """
+                curl -i \
+                  -H "Authorization: Bearer %env.PUBLISHING_TOKEN%" \
+                  https://packages.jetbrains.team/files/p/ktor/files/plugin-registry/ \
+                  --upload-file build/distributions/registry.tar.gz
+            """
+        }
+    }
+
+    triggers {
+        vcs {
+            branchFilter = "+:<default>"
+        }
+    }
+})

--- a/.teamcity/src/subprojects/build/generator/TestPluginRegistry.kt
+++ b/.teamcity/src/subprojects/build/generator/TestPluginRegistry.kt
@@ -1,0 +1,56 @@
+package subprojects.build.generator
+
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import subprojects.VCSPluginRegistry
+
+object TestPluginRegistry : BuildType({
+    id("KtorPluginRegistryVerify")
+    name = "Test plugin registry"
+    vcs {
+        root(VCSPluginRegistry)
+    }
+
+    steps {
+        gradle {
+            name = "Test plugin registry"
+            tasks = "resolvePlugins detekt test buildRegistry"
+            buildFile = "build.gradle.kts"
+            jdkHome = "%env.JDK_11%"
+        }
+    }
+
+    features {
+        pullRequests {
+            vcsRootExtId = VCSPluginRegistry.id.toString()
+            provider = github {
+                authType = token {
+                    token = "%github.token%"
+                }
+                filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
+            }
+        }
+        commitStatusPublisher {
+            vcsRootExtId = VCSPluginRegistry.id.toString()
+
+            publisher = github {
+                githubUrl = "https://api.github.com"
+                authType = personalToken {
+                    token = "%github.token%"
+                }
+            }
+        }
+    }
+
+    triggers {
+        vcs {
+            branchFilter = """
+                +:refs/pull/*
+            """.trimIndent()
+        }
+    }
+})


### PR DESCRIPTION
So now we'll push the website build up to Space and serve it from the back-end.  I'll just need to introduce the static files endpoint and download the archive there, then also add the deployment for the cloud console with the internal URL and testing parameters.

And for a follow-up to why the TC script builds were failing - nobody has any idea why but it magically stopped failing so I guess we're good now 🤡 