### PR TITLE
Trigger builds only for suitable targets

### DIFF
--- a/.teamcity/src/subprojects/build/core/CodeStyleVerifyBuild.kt
+++ b/.teamcity/src/subprojects/build/core/CodeStyleVerifyBuild.kt
@@ -32,11 +32,9 @@ object CodeStyleVerify : BuildType({
             // we only verify *.kt, project and plugin configs
             triggerRules = """
                 +:**/*.kt
-                +:gradle/codestyle.gradle*
-                +:build.gradle*
-                +:**/*.gradle*
-                +:gradle.properties
-                +:settings.gradle
+                +:**/*.gradle
+                +:**/*.gradle.kts
+                +:**/gradle.properties
                 +:.editorconfig
             """.trimIndent()
         }

--- a/.teamcity/src/subprojects/build/core/JDKBuild.kt
+++ b/.teamcity/src/subprojects/build/core/JDKBuild.kt
@@ -6,14 +6,20 @@ import subprojects.*
 import subprojects.build.*
 import subprojects.release.*
 
-class CoreBuild(private val osJdkEntry: OSJDKEntry) : BuildType({
+class JDKBuild(private val osJdkEntry: OSJDKEntry) : BuildType({
     id("KtorMatrixCore_${osJdkEntry.osEntry.name}${osJdkEntry.jdkEntry.name}".toId())
     name = "${osJdkEntry.jdkEntry.name} on ${osJdkEntry.osEntry.name}"
     val artifactsToPublish = formatArtifacts("+:**/build/**/*.jar")
     artifactRules = formatArtifacts(artifactsToPublish, junitReportArtifact, memoryReportArtifact)
+
     vcs {
         root(VCSCore)
     }
+
+    triggers {
+        onBuildTargetChanges(BuildTarget.JVM)
+    }
+
     steps {
         when (osJdkEntry.osEntry) {
             windows -> {

--- a/.teamcity/src/subprojects/build/core/JavaScriptBuild.kt
+++ b/.teamcity/src/subprojects/build/core/JavaScriptBuild.kt
@@ -11,9 +11,15 @@ class JavaScriptBuild(private val jsEntry: JSEntry) : BuildType({
     name = "JavaScript on ${jsEntry.name}"
     val artifactsToPublish = formatArtifacts("+:**/build/**/*.jar")
     artifactRules = formatArtifacts(artifactsToPublish, junitReportArtifact, memoryReportArtifact)
+
     vcs {
         root(VCSCore)
     }
+
+    triggers {
+        onBuildTargetChanges(BuildTarget.JS)
+    }
+
     steps {
         gradle {
             name = "Build Js"

--- a/.teamcity/src/subprojects/build/core/NativeBuild.kt
+++ b/.teamcity/src/subprojects/build/core/NativeBuild.kt
@@ -30,9 +30,15 @@ class NativeBuild(private val osEntry: OSEntry) : BuildType({
     name = "Native on ${osEntry.name} ${osEntry.osArch ?: "x64"}"
     val artifactsToPublish = formatArtifacts("+:**/build/**/*.klib", "+:**/build/**/*.exe", "+:**/build/**/*.kexe")
     artifactRules = formatArtifacts(artifactsToPublish, junitReportArtifact, memoryReportArtifact)
+
     vcs {
         root(VCSCore)
     }
+
+    triggers {
+        onBuildTargetChanges(BuildTarget.Native(osEntry))
+    }
+
     steps {
         when (osEntry) {
             windows -> {

--- a/.teamcity/src/subprojects/build/core/ProjectCore.kt
+++ b/.teamcity/src/subprojects/build/core/ProjectCore.kt
@@ -25,7 +25,7 @@ object ProjectCore : Project({
 
     val jpmsCheck = JPMSCheckBuild
     val apiCheck = APICheckBuild
-    val osJdkBuilds = osJdks.map(::CoreBuild)
+    val osJdkBuilds = osJdks.map(::JDKBuild)
     // Skip Native Windows build for now, it is not working.
     val nativeBuilds = (operatingSystems - windows).map(::NativeBuild)
     val javaScriptBuilds = javaScriptEngines.map(::JavaScriptBuild)

--- a/.teamcity/src/subprojects/build/core/WasmJsBuild.kt
+++ b/.teamcity/src/subprojects/build/core/WasmJsBuild.kt
@@ -11,11 +11,16 @@ class WasmJsBuild(private val jsEntry: JSEntry) : BuildType({
     name = "WasmJS on ${jsEntry.name}"
     val artifactsToPublish = formatArtifacts("+:**/build/**/*.jar")
     artifactRules = formatArtifacts(artifactsToPublish, junitReportArtifact, memoryReportArtifact)
+
     vcs {
         root(VCSCore)
     }
-    steps {
 
+    triggers {
+        onBuildTargetChanges(BuildTarget.WasmJS)
+    }
+
+    steps {
         gradle {
             name = "Build Wasm Js"
             tasks = "cleanWasmJsTest wasmJsTest --no-parallel --continue --info -Penable-js-tests"


### PR DESCRIPTION
Run builds only on the targets affected by changes. Changes in JVM code shouldn't trigger a native build and vice versa.