### PR TITLE
Clean up trigger rules and branch filters

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,4 +1,5 @@
 import jetbrains.buildServer.configs.kotlin.*
+import jetbrains.buildServer.configs.kotlin.projectFeatures.*
 import subprojects.*
 import subprojects.benchmarks.*
 import subprojects.build.*
@@ -58,6 +59,16 @@ project {
     // DO NOT REMOVE
     params {
         param("teamcity.ui.settings.readOnly", "true")
+    }
+
+    features {
+        untrustedBuildsSettings {
+            id = "UntrustedBuildsPolicy"
+            defaultAction = UntrustedBuildsSettings.DefaultAction.APPROVE
+            approvalRules = "group:ALL_USERS_GROUP:1"
+            manualRunsApproved = true
+            enableLog = true
+        }
     }
 
     subProject(ProjectBuild)

--- a/.teamcity/src/subprojects/Triggers.kt
+++ b/.teamcity/src/subprojects/Triggers.kt
@@ -77,8 +77,8 @@ fun Triggers.onBuildTargetChanges(target: BuildTarget) {
     val targetSources = target.sourceSets.joinToString("\n") { sourceSet ->
         // Include the sourceSet itself and all possible suffixes like Arm64/X64, Main/Test, Simulator/Device
         """
-            +:**/$sourceSet/**
-            +:**/$sourceSet*/**
+            +:**/ktor-*/$sourceSet/**
+            +:**/ktor-*/$sourceSet*/**
         """.trimIndent()
     }
 

--- a/.teamcity/src/subprojects/Triggers.kt
+++ b/.teamcity/src/subprojects/Triggers.kt
@@ -15,7 +15,7 @@ import subprojects.build.*
 object BranchFilter {
     const val AllBranches = "+:*"
     const val DefaultBranch = "+:<default>"
-    const val PullRequest = "+:pull/*"
+    const val PullRequest = "+pr:*"
     const val DefaultOrPullRequest = "$DefaultBranch\n$PullRequest"
 }
 

--- a/.teamcity/src/subprojects/Triggers.kt
+++ b/.teamcity/src/subprojects/Triggers.kt
@@ -1,0 +1,101 @@
+package subprojects
+
+import jetbrains.buildServer.configs.kotlin.*
+import jetbrains.buildServer.configs.kotlin.triggers.*
+import subprojects.build.*
+
+fun Triggers.onChangeDefaultOrPullRequest() {
+    vcs {
+        triggerRules = """
+            -:*.md
+            -:.gitignore
+            -:user=*+renovate[bot]:.
+            -:user=*+dependabot[bot]:.
+        """.trimIndent()
+        branchFilter = """
+            +:pull/*
+            +:<default>
+        """
+    }
+}
+
+fun Triggers.onChangeAllBranchesTrigger() {
+    vcs {
+        triggerRules = """
+            -:*.md
+            -:.gitignore
+            -:user=*+renovate[bot]:.
+            -:user=*+dependabot[bot]:.
+        """.trimIndent()
+        branchFilter = """
+            +:*
+            -:dependabot/*
+            -:renovate/*
+        """.trimIndent()
+    }
+}
+
+fun Triggers.nightlyEAPBranchesTrigger() {
+    schedule {
+        schedulingPolicy = daily {
+            hour = 20
+        }
+        triggerBuild = always()
+    }
+}
+
+fun Triggers.onBuildTargetChanges(target: BuildTarget) {
+    val targetSources = target.sourceSets.joinToString("\n") { sourceSet ->
+        // Include the sourceSet itself and all possible suffixes like Arm64/X64, Main/Test, Simulator/Device
+        """
+            +:**/$sourceSet/**
+            +:**/$sourceSet*/**
+        """.trimIndent()
+    }
+
+    val gradle = """
+        +:**/*.gradle
+        +:**/*.gradle.kts
+        +:**/*.versions.toml
+        +:buildSrc/**
+        +:**/gradle-wrapper.properties
+        +:**/gradle.properties
+    """.trimIndent()
+
+    vcs {
+        triggerRules = listOf(targetSources, gradle).joinToString("\n")
+    }
+}
+
+// Should be in sync with TargetsConfig.kt in the Ktor project
+class BuildTarget(sourceSets: List<String>) {
+
+    constructor(vararg sourceSets: String) : this(sourceSets.toList())
+
+    val sourceSets = sourceSets + "common"
+
+    companion object {
+        val JVM = BuildTarget("jvm", "jvmAndPosix", "jvmAndNix")
+        val JS = BuildTarget("js", "jsAndWasmShared")
+        val WasmJS = BuildTarget("wasmJs", "jsAndWasmShared")
+
+        fun Native(osEntry: OSEntry) = BuildTarget(
+            listOf("desktop", "posix", "jvmAndPosix") +
+                nixSourceSets(osEntry) +
+                osSourceSets(osEntry)
+        )
+
+        /** Source sets that are built only on a specific OS. */
+        private fun osSourceSets(osEntry: OSEntry): List<String> = when (osEntry) {
+            macOS -> listOf("darwin", "macos", "ios", "tvos", "watchos")
+            linux -> listOf("linux")
+            windows -> listOf("windows", "mingw")
+            else -> emptyList()
+        }
+
+        private fun nixSourceSets(osEntry: OSEntry): List<String> = when (osEntry) {
+            linux, macOS -> listOf("nix", "jvmAndNix")
+            else -> emptyList()
+        }
+    }
+}

--- a/.teamcity/src/subprojects/Triggers.kt
+++ b/.teamcity/src/subprojects/Triggers.kt
@@ -45,11 +45,11 @@ object TriggerRules {
     """.trimIndent()
 }
 
-fun Triggers.onChangeDefaultOrPullRequest() {
+fun Triggers.onChangeDefaultOrPullRequest(additionalTriggerRules: String = "") {
     vcs {
         triggerRules = """
             ${TriggerRules.IgnoreNonCodeChanges}
-            ${TriggerRules.IgnoreBotCommits}
+            $additionalTriggerRules
         """.trimIndent()
         branchFilter = BranchFilter.DefaultOrPullRequest
     }
@@ -59,7 +59,6 @@ fun Triggers.onChangeAllBranchesTrigger() {
     vcs {
         triggerRules = """
             ${TriggerRules.IgnoreNonCodeChanges}
-            ${TriggerRules.IgnoreBotCommits}
         """.trimIndent()
         branchFilter = BranchFilter.AllBranches
     }

--- a/.teamcity/src/subprojects/Triggers.kt
+++ b/.teamcity/src/subprojects/Triggers.kt
@@ -4,34 +4,64 @@ import jetbrains.buildServer.configs.kotlin.*
 import jetbrains.buildServer.configs.kotlin.triggers.*
 import subprojects.build.*
 
+/**
+ * A set of common branch filters.
+ *
+ * Note that branches in branch filters should be references by
+ * [logical names](https://www.jetbrains.com/help/teamcity/2024.07/working-with-feature-branches.html#Logical+Branch+Name).
+ *
+ * [Docs: Branch Filter Format](https://www.jetbrains.com/help/teamcity/2024.07/branch-filter.html#Branch+Filter+Format)
+ */
+object BranchFilter {
+    const val AllBranches = "+:*"
+    const val DefaultBranch = "+:<default>"
+    const val PullRequest = "+:pull/*"
+    const val DefaultOrPullRequest = "$DefaultBranch\n$PullRequest"
+}
+
+/**
+ * A set of common trigger rules.
+ *
+ * [Docs: VCS Trigger Rules](https://www.jetbrains.com/help/teamcity/2024.07/configuring-vcs-triggers.html#vcs-trigger-rules-1)
+ */
+object TriggerRules {
+    val IgnoreNonCodeChanges = """
+        -:*.md
+        -:.gitignore
+    """.trimIndent()
+
+    val IgnoreBotCommits = """
+        -:user=*+renovate[bot]:.
+        -:user=*+dependabot[bot]:.
+    """.trimIndent()
+
+    val GradleFiles = """
+        +:**/*.gradle
+        +:**/*.gradle.kts
+        +:**/*.versions.toml
+        +:buildSrc/**
+        +:**/gradle-wrapper.properties
+        +:**/gradle.properties
+    """.trimIndent()
+}
+
 fun Triggers.onChangeDefaultOrPullRequest() {
     vcs {
         triggerRules = """
-            -:*.md
-            -:.gitignore
-            -:user=*+renovate[bot]:.
-            -:user=*+dependabot[bot]:.
+            ${TriggerRules.IgnoreNonCodeChanges}
+            ${TriggerRules.IgnoreBotCommits}
         """.trimIndent()
-        branchFilter = """
-            +:pull/*
-            +:<default>
-        """
+        branchFilter = BranchFilter.DefaultOrPullRequest
     }
 }
 
 fun Triggers.onChangeAllBranchesTrigger() {
     vcs {
         triggerRules = """
-            -:*.md
-            -:.gitignore
-            -:user=*+renovate[bot]:.
-            -:user=*+dependabot[bot]:.
+            ${TriggerRules.IgnoreNonCodeChanges}
+            ${TriggerRules.IgnoreBotCommits}
         """.trimIndent()
-        branchFilter = """
-            +:*
-            -:dependabot/*
-            -:renovate/*
-        """.trimIndent()
+        branchFilter = BranchFilter.AllBranches
     }
 }
 
@@ -53,17 +83,12 @@ fun Triggers.onBuildTargetChanges(target: BuildTarget) {
         """.trimIndent()
     }
 
-    val gradle = """
-        +:**/*.gradle
-        +:**/*.gradle.kts
-        +:**/*.versions.toml
-        +:buildSrc/**
-        +:**/gradle-wrapper.properties
-        +:**/gradle.properties
-    """.trimIndent()
-
     vcs {
-        triggerRules = listOf(targetSources, gradle).joinToString("\n")
+        triggerRules = """
+            $targetSources
+            ${TriggerRules.GradleFiles}
+        """.trimIndent()
+        branchFilter = BranchFilter.DefaultOrPullRequest
     }
 }
 

--- a/.teamcity/src/subprojects/VcsRoots.kt
+++ b/.teamcity/src/subprojects/VcsRoots.kt
@@ -1,9 +1,6 @@
 package subprojects
 
-import jetbrains.buildServer.configs.kotlin.*
-import jetbrains.buildServer.configs.kotlin.triggers.*
 import jetbrains.buildServer.configs.kotlin.vcs.*
-import subprojects.build.*
 
 const val VCSUsername = "hhariri"
 const val VCSToken = "%github.token%"
@@ -130,99 +127,3 @@ open class PasswordVcsRoot(init: GitVcsRoot.() -> Unit) : KtorVcsRoot({
 
     init()
 })
-
-fun Triggers.onChangeDefaultOrPullRequest() {
-    vcs {
-        triggerRules = """
-            -:*.md
-            -:.gitignore
-            -:user=*+renovate[bot]:.
-            -:user=*+dependabot[bot]:.
-        """.trimIndent()
-        branchFilter = """
-            +:pull/*
-            +:<default>
-        """
-    }
-}
-
-fun Triggers.onChangeAllBranchesTrigger() {
-    vcs {
-        triggerRules = """
-            -:*.md
-            -:.gitignore
-            -:user=*+renovate[bot]:.
-            -:user=*+dependabot[bot]:.
-        """.trimIndent()
-        branchFilter = """
-            +:*
-            -:dependabot/*
-            -:renovate/*
-        """.trimIndent()
-    }
-}
-
-fun Triggers.nightlyEAPBranchesTrigger() {
-    schedule {
-        schedulingPolicy = daily {
-            hour = 20
-        }
-        triggerBuild = always()
-    }
-}
-
-fun Triggers.onBuildTargetChanges(target: BuildTarget) {
-    val targetSources = target.sourceSets.joinToString("\n") { sourceSet ->
-        // Include the sourceSet itself and all possible suffixes like Arm64/X64, Main/Test, Simulator/Device
-        """
-            +:**/$sourceSet/**
-            +:**/$sourceSet*/**
-        """.trimIndent()
-    }
-
-    val gradle = """
-        +:**/*.gradle
-        +:**/*.gradle.kts
-        +:**/*.versions.toml
-        +:buildSrc/**
-        +:**/gradle-wrapper.properties
-        +:**/gradle.properties
-    """.trimIndent()
-
-    vcs {
-        triggerRules = listOf(targetSources, gradle).joinToString("\n")
-    }
-}
-
-// Should be in sync with TargetsConfig.kt in the Ktor project
-class BuildTarget(sourceSets: List<String>) {
-
-    constructor(vararg sourceSets: String) : this(sourceSets.toList())
-
-    val sourceSets = sourceSets + "common"
-
-    companion object {
-        val JVM = BuildTarget("jvm", "jvmAndPosix", "jvmAndNix")
-        val JS = BuildTarget("js", "jsAndWasmShared")
-        val WasmJS = BuildTarget("wasmJs", "jsAndWasmShared")
-
-        fun Native(osEntry: OSEntry) = BuildTarget(
-            listOf("desktop", "posix", "jvmAndPosix") +
-                nixSourceSets(osEntry) +
-                osSourceSets(osEntry)
-        )
-
-        /** Source sets that are built only on a specific OS. */
-        private fun osSourceSets(osEntry: OSEntry): List<String> = when (osEntry) {
-            macOS -> listOf("darwin", "macos", "ios", "tvos", "watchos")
-            linux -> listOf("linux")
-            windows -> listOf("windows", "mingw")
-            else -> emptyList()
-        }
-
-        private fun nixSourceSets(osEntry: OSEntry): List<String> = when (osEntry) {
-            linux, macOS -> listOf("nix", "jvmAndNix")
-            else -> emptyList()
-        }
-    }
-}

--- a/.teamcity/src/subprojects/VcsRoots.kt
+++ b/.teamcity/src/subprojects/VcsRoots.kt
@@ -5,11 +5,12 @@ import jetbrains.buildServer.configs.kotlin.triggers.*
 import jetbrains.buildServer.configs.kotlin.vcs.*
 import subprojects.build.*
 
-const val defaultBranch = "refs/heads/main"
 const val VCSUsername = "hhariri"
 const val VCSToken = "%github.token%"
-const val DefaultAndPullRequests = "+:$defaultBranch\n+:refs/(pull/*)/head"
-const val AllBranchesAndPullRequests = "+:refs/heads/*\n+:refs/(pull/*)/head"
+
+private const val defaultBranch = "refs/heads/(main)"
+private const val DefaultAndPullRequests = "+:$defaultBranch\n+:refs/(pull/*)/head"
+private const val AllBranchesAndPullRequests = "+:refs/heads/*\n+:refs/(pull/*)/head"
 
 object VCSCore : PasswordVcsRoot({
     name = "Ktor Core"

--- a/.teamcity/src/subprojects/benchmarks/ProjectBenchmarks.kt
+++ b/.teamcity/src/subprojects/benchmarks/ProjectBenchmarks.kt
@@ -48,9 +48,7 @@ object ProjectBenchmarks : Project({
             require(os = linux.agentString, minMemoryMB = 7000)
         }
 
-        features {
-            githubCommitStatusPublisher()
-        }
+        defaultBuildFeatures(VCSCore.id.toString())
     }
 
     features {

--- a/.teamcity/src/subprojects/build/ProjectBuild.kt
+++ b/.teamcity/src/subprojects/build/ProjectBuild.kt
@@ -127,14 +127,15 @@ fun BuildType.defaultBuildFeatures(rootId: String) {
 fun BuildFeatures.githubPullRequestsLoader(rootId: String) {
     pullRequests {
         vcsRootExtId = rootId
+
         provider = github {
             authType = token {
                 token = VCSToken
             }
             filterTargetBranch = """
-            +:*
-            -:pull/*
-        """.trimIndent()
+                +:refs/heads/*
+                -:refs/pull/*/head
+            """.trimIndent()
             filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
         }
     }

--- a/.teamcity/src/subprojects/build/ProjectBuild.kt
+++ b/.teamcity/src/subprojects/build/ProjectBuild.kt
@@ -133,7 +133,7 @@ fun BuildFeatures.githubPullRequestsLoader(rootId: String) {
                 +:refs/heads/*
                 -:refs/pull/*/head
             """.trimIndent()
-            filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
+            filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
         }
     }
 }

--- a/.teamcity/src/subprojects/build/ProjectBuild.kt
+++ b/.teamcity/src/subprojects/build/ProjectBuild.kt
@@ -106,9 +106,6 @@ fun BuildType.defaultBuildFeatures(rootId: String) {
 
         githubPullRequestsLoader(rootId)
         githubCommitStatusPublisher(rootId)
-        sharedResources {
-            readLock("TestInfrastructure")
-        }
     }
 
     failureConditions {

--- a/.teamcity/src/subprojects/build/core/APICheckBuild.kt
+++ b/.teamcity/src/subprojects/build/core/APICheckBuild.kt
@@ -9,12 +9,15 @@ object APICheckBuild : BuildType({
     id("KtorMatrixCore_APICheck".toId())
     name = "Check API"
     artifactRules = formatArtifacts(memoryReportArtifact)
+
     vcs {
         root(VCSCore)
     }
+
     triggers {
         onChangeDefaultOrPullRequest()
     }
+
     steps {
         gradle {
             buildFile = "build.gradle.kts"
@@ -23,6 +26,7 @@ object APICheckBuild : BuildType({
             jdkHome = "%env.${javaLTS.env}%"
         }
     }
+
     defaultBuildFeatures(VCSCore.id.toString())
 
     requirements {

--- a/.teamcity/src/subprojects/build/core/APICheckBuild.kt
+++ b/.teamcity/src/subprojects/build/core/APICheckBuild.kt
@@ -15,7 +15,7 @@ object APICheckBuild : BuildType({
     }
 
     triggers {
-        onChangeDefaultOrPullRequest()
+        onChangeDefaultOrPullRequest(additionalTriggerRules = TriggerRules.IgnoreBotCommits)
     }
 
     steps {

--- a/.teamcity/src/subprojects/build/core/CodeStyleVerifyBuild.kt
+++ b/.teamcity/src/subprojects/build/core/CodeStyleVerifyBuild.kt
@@ -31,12 +31,11 @@ object CodeStyleVerify : BuildType({
         vcs {
             // we only verify *.kt, project and plugin configs
             triggerRules = """
+                ${TriggerRules.GradleFiles}
                 +:**/*.kt
-                +:**/*.gradle
-                +:**/*.gradle.kts
-                +:**/gradle.properties
                 +:.editorconfig
             """.trimIndent()
+            branchFilter = BranchFilter.PullRequest
         }
     }
 

--- a/.teamcity/src/subprojects/build/core/DependenciesCheckBuild.kt
+++ b/.teamcity/src/subprojects/build/core/DependenciesCheckBuild.kt
@@ -1,7 +1,6 @@
 package subprojects.build.core
 
 import jetbrains.buildServer.configs.kotlin.*
-import jetbrains.buildServer.configs.kotlin.buildFeatures.*
 import jetbrains.buildServer.configs.kotlin.buildSteps.*
 import subprojects.*
 import subprojects.build.*
@@ -23,11 +22,7 @@ class DependenciesCheckBuild : BuildType({
         }
     }
 
-    features {
-        perfmon {}
-        githubPullRequestsLoader(VCSCore.id.toString())
-        githubCommitStatusPublisher(VCSCore.id.toString())
-    }
+    defaultBuildFeatures(VCSCore.id.toString())
 
     requirements {
         require(os = linux.agentString, minMemoryMB = 7000)

--- a/.teamcity/src/subprojects/build/core/JPMSCheckBuild.kt
+++ b/.teamcity/src/subprojects/build/core/JPMSCheckBuild.kt
@@ -8,12 +8,15 @@ import subprojects.build.*
 object JPMSCheckBuild: BuildType({
     id("JPMSCheck".toId())
     name = "Check JPMS"
+
     vcs {
         root(VCSCore)
     }
+
     triggers {
         onChangeDefaultOrPullRequest()
     }
+
     steps {
         gradle {
             buildFile = "build.gradle.kts"
@@ -22,6 +25,7 @@ object JPMSCheckBuild: BuildType({
             jdkHome = "%env.${javaLTS.env}%"
         }
     }
+
     defaultBuildFeatures(VCSCore.id.toString())
 
     requirements {

--- a/.teamcity/src/subprojects/build/core/ProjectCore.kt
+++ b/.teamcity/src/subprojects/build/core/ProjectCore.kt
@@ -31,11 +31,13 @@ object ProjectCore : Project({
 
     buildType {
         allowExternalStatus = true
-        createCompositeBuild("KtorCore_All", "Build All Core", VCSCore, allBuilds, withTrigger = TriggerType.VERIFICATION)
-
-        features {
-            githubCommitStatusPublisher(VCSSamples.id.toString())
-        }
+        createCompositeBuild(
+            buildId = "KtorCore_All",
+            buildName = "Build All Core",
+            vcsRoot = VCSCore,
+            builds = allBuilds,
+            withTrigger = TriggerType.VERIFICATION,
+        )
     }
 
     buildType(CodeStyleVerify)
@@ -63,6 +65,7 @@ fun BuildType.createCompositeBuild(
     vcs {
         root(vcsRoot)
     }
+
     triggers {
         when (withTrigger) {
             TriggerType.ALL_BRANCHES -> onChangeAllBranchesTrigger()
@@ -70,6 +73,7 @@ fun BuildType.createCompositeBuild(
             TriggerType.NONE -> {}
         }
     }
+
     dependencies {
         builds.mapNotNull { it.id }.forEach { id ->
             snapshot(id) {
@@ -77,6 +81,8 @@ fun BuildType.createCompositeBuild(
             }
         }
     }
+
+    defaultBuildFeatures(vcsRoot.id.toString())
 }
 
 fun Requirements.require(os: String, osarch: String? = null, minMemoryMB: Int = -1) {

--- a/.teamcity/src/subprojects/build/core/StressTestBuild.kt
+++ b/.teamcity/src/subprojects/build/core/StressTestBuild.kt
@@ -19,7 +19,7 @@ class StressTestBuild(private val osJVMComboEntry: OSJDKEntry) : BuildType({
                 hour = 8
                 timezone = "Europe/Moscow"
             }
-            branchFilter = "+:<default>"
+            branchFilter = BranchFilter.DefaultBranch
             triggerBuild = always()
             param("revisionRuleBuildBranch", "<default>")
         }

--- a/.teamcity/src/subprojects/build/generator/BuildGeneratorWebsite.kt
+++ b/.teamcity/src/subprojects/build/generator/BuildGeneratorWebsite.kt
@@ -62,9 +62,7 @@ object BuildGeneratorWebsite : BuildType({
 
     triggers {
         vcs {
-            branchFilter = """
-                +:refs/pull/*
-            """.trimIndent()
+            branchFilter = BranchFilter.PullRequest
         }
     }
 })

--- a/.teamcity/src/subprojects/build/generator/BuildGeneratorWebsite.kt
+++ b/.teamcity/src/subprojects/build/generator/BuildGeneratorWebsite.kt
@@ -1,10 +1,10 @@
 package subprojects.build.generator
 
 import jetbrains.buildServer.configs.kotlin.*
-import jetbrains.buildServer.configs.kotlin.buildFeatures.*
 import jetbrains.buildServer.configs.kotlin.buildSteps.*
 import jetbrains.buildServer.configs.kotlin.triggers.*
 import subprojects.*
+import subprojects.build.*
 
 object BuildGeneratorWebsite : BuildType({
     id("KtorGeneratorWebsite_Test")
@@ -38,27 +38,7 @@ object BuildGeneratorWebsite : BuildType({
         }
     }
 
-    features {
-        pullRequests {
-            vcsRootExtId = VCSKtorGeneratorWebsite.id.toString()
-            provider = github {
-                authType = token {
-                    token = "%github.token%"
-                }
-                filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
-            }
-        }
-        commitStatusPublisher {
-            vcsRootExtId = VCSKtorGeneratorWebsite.id.toString()
-
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "%github.token%"
-                }
-            }
-        }
-    }
+    defaultBuildFeatures(VCSKtorGeneratorWebsite.id.toString())
 
     triggers {
         vcs {

--- a/.teamcity/src/subprojects/build/generator/PublishPluginRegistry.kt
+++ b/.teamcity/src/subprojects/build/generator/PublishPluginRegistry.kt
@@ -35,7 +35,7 @@ object PublishPluginRegistry : BuildType({
 
     triggers {
         vcs {
-            branchFilter = "+:<default>"
+            branchFilter = BranchFilter.DefaultBranch
         }
     }
 })

--- a/.teamcity/src/subprojects/build/generator/TestGeneratorBackEnd.kt
+++ b/.teamcity/src/subprojects/build/generator/TestGeneratorBackEnd.kt
@@ -1,10 +1,10 @@
 package subprojects.build.generator
 
 import jetbrains.buildServer.configs.kotlin.*
-import jetbrains.buildServer.configs.kotlin.buildFeatures.*
 import jetbrains.buildServer.configs.kotlin.buildSteps.*
 import jetbrains.buildServer.configs.kotlin.triggers.*
 import subprojects.*
+import subprojects.build.*
 
 object TestGeneratorBackEnd : BuildType({
     id("KtorGeneratorBackendVerify")
@@ -26,27 +26,7 @@ object TestGeneratorBackEnd : BuildType({
         }
     }
 
-    features {
-        pullRequests {
-            vcsRootExtId = VCSKtorGeneratorBackend.id.toString()
-            provider = github {
-                authType = token {
-                    token = "%github.token%"
-                }
-                filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
-            }
-        }
-        commitStatusPublisher {
-            vcsRootExtId = VCSKtorGeneratorBackend.id.toString()
-
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "%github.token%"
-                }
-            }
-        }
-    }
+    defaultBuildFeatures(VCSKtorGeneratorBackend.id.toString())
 
     triggers {
         vcs {}

--- a/.teamcity/src/subprojects/build/generator/TestPluginRegistry.kt
+++ b/.teamcity/src/subprojects/build/generator/TestPluginRegistry.kt
@@ -1,10 +1,10 @@
 package subprojects.build.generator
 
 import jetbrains.buildServer.configs.kotlin.*
-import jetbrains.buildServer.configs.kotlin.buildFeatures.*
 import jetbrains.buildServer.configs.kotlin.buildSteps.*
 import jetbrains.buildServer.configs.kotlin.triggers.*
 import subprojects.*
+import subprojects.build.*
 
 object TestPluginRegistry : BuildType({
     id("KtorPluginRegistryVerify")
@@ -22,27 +22,7 @@ object TestPluginRegistry : BuildType({
         }
     }
 
-    features {
-        pullRequests {
-            vcsRootExtId = VCSPluginRegistry.id.toString()
-            provider = github {
-                authType = token {
-                    token = "%github.token%"
-                }
-                filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
-            }
-        }
-        commitStatusPublisher {
-            vcsRootExtId = VCSPluginRegistry.id.toString()
-
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "%github.token%"
-                }
-            }
-        }
-    }
+    defaultBuildFeatures(VCSPluginRegistry.id.toString())
 
     triggers {
         vcs {}

--- a/.teamcity/src/subprojects/cli/ProjectCLI.kt
+++ b/.teamcity/src/subprojects/cli/ProjectCLI.kt
@@ -1,7 +1,6 @@
 package subprojects.cli
 
 import jetbrains.buildServer.configs.kotlin.*
-import jetbrains.buildServer.configs.kotlin.buildFeatures.*
 import jetbrains.buildServer.configs.kotlin.buildSteps.*
 import subprojects.*
 import subprojects.build.*
@@ -347,13 +346,7 @@ object BuildCLI: BuildType({
         require(os = linux.agentString)
     }
 
-    features {
-        perfmon {
-        }
-
-        githubPullRequestsLoader(VCSKtorCLI.id.toString())
-        githubCommitStatusPublisher(VCSKtorCLI.id.toString())
-    }
+    defaultBuildFeatures(VCSKtorCLI.id.toString())
 })
 
 private fun BuildSteps.buildFor(os: String, arch: String) {

--- a/.teamcity/src/subprojects/plugins/ProjectGradlePlugin.kt
+++ b/.teamcity/src/subprojects/plugins/ProjectGradlePlugin.kt
@@ -77,9 +77,7 @@ object ProjectGradlePlugin : Project({
 
         vcs {
             root(VCSKtorBuildPlugins)
-            branchFilter = """
-                +:<default>
-            """.trimIndent()
+            branchFilter = BranchFilter.DefaultBranch
         }
 
         triggers {

--- a/.teamcity/src/subprojects/release/ReleaseBuild.kt
+++ b/.teamcity/src/subprojects/release/ReleaseBuild.kt
@@ -58,7 +58,7 @@ object ReleaseBuild : BuildType({
             vcsRootId = "${VCSCore.id}"
             labelingPattern = "%reverse.dep.*.releaseVersion%"
             successfulOnly = true
-            branchFilter = "+:<default>"
+            branchFilter = BranchFilter.DefaultBranch
         }
     }
 

--- a/.teamcity/src/subprojects/release/generator/ProjectReleaseGeneratorWebsite.kt
+++ b/.teamcity/src/subprojects/release/generator/ProjectReleaseGeneratorWebsite.kt
@@ -68,7 +68,7 @@ object ProjectReleaseGeneratorWebsite : Project({
 
         triggers {
             vcs {
-                branchFilter = "+:<default>"
+                branchFilter = BranchFilter.DefaultBranch
             }
         }
     }


### PR DESCRIPTION
- Fixed the format of branch filters - full reference where needed and a logical name for the rest
- Enabled approvals for untrusted builds for the sake of security (be ready to approve contributors' builds)
- Applied the pull-requests feature to all builds that should be triggered by pull requests, so now it should be possible to use `+pr:*` syntax in rules
- Gathered trigger rules and branch filters into objects to make them simpler to reuse
- Disabled ignoring for bot commits
- Aligned trigger branch rules of builds with the composite build to prevent builds on branches without PRs

It is simpler to review commit-by-commit

I hope after these changes we will get back running composite build on the main branch and get rid of builds running on branches without PRs.