### PR TITLE
Workaround to avoid implicit dependency between different targets

### DIFF
--- a/.teamcity/src/subprojects/eap/PublishSpaceBuilds.kt
+++ b/.teamcity/src/subprojects/eap/PublishSpaceBuilds.kt
@@ -170,14 +170,7 @@ object PublishAndroidNativeToSpace : BuildType({
         root(VCSCoreEAP)
     }
     steps {
-        releaseToSpace(
-            listOf(
-                "publishAndroidNativeArm64PublicationToMavenRepository",
-                "publishAndroidNativeArm32PublicationToMavenRepository",
-                "publishAndroidNativeX64PublicationToMavenRepository",
-                "publishAndroidNativeX86PublicationToMavenRepository",
-            )
-        )
+        releaseToSpace(ANDROID_NATIVE_PUBLISH_TASKS)
     }
     params {
         param("eapVersion", SetBuildNumber.depParamRefs.buildNumber.ref)

--- a/.teamcity/src/subprojects/release/publishing/PublicationConstants.kt
+++ b/.teamcity/src/subprojects/release/publishing/PublicationConstants.kt
@@ -19,5 +19,12 @@ internal val MACOS_PUBLISH_TASKS = listOf(
     "publishWatchosDeviceArm64PublicationToMavenRepository",
 )
 
+internal val ANDROID_NATIVE_PUBLISH_TASKS = listOf(
+    "publishAndroidNativeArm64PublicationToMavenRepository",
+    "publishAndroidNativeArm32PublicationToMavenRepository",
+    "publishAndroidNativeX64PublicationToMavenRepository",
+    "publishAndroidNativeX86PublicationToMavenRepository",
+)
+
 internal val MACOS_GRADLE_ARGS =
     "--parallel -Psigning.gnupg.executable=gpg -Psigning.gnupg.homeDir=%env.SIGN_KEY_LOCATION%/.gnupg"

--- a/.teamcity/src/subprojects/release/publishing/PublishMavenBuilds.kt
+++ b/.teamcity/src/subprojects/release/publishing/PublishMavenBuilds.kt
@@ -152,6 +152,8 @@ object PublishMacOSNativeToMaven : BuildType({
             name = "Obtain Library Dependencies"
             scriptContent = macSoftware
         }
+        // Publish targets in separate steps to avoid implicit dependency between different targets
+        // Issue: https://youtrack.jetbrains.com/issue/KTOR-7556/
         MACOS_PUBLISH_TASKS.forEach {
             createSonatypeRepository(it)
             publish(it, MACOS_GRADLE_ARGS)
@@ -174,14 +176,12 @@ object PublishAndroidNativeToMaven : BuildType({
         configureReleaseVersion()
     }
     steps {
-        createSonatypeRepository("Android Native")
-        publish(
-            "publishAndroidNativeArm64PublicationToMavenRepository " +
-                "publishAndroidNativeArm32PublicationToMavenRepository " +
-                "publishAndroidNativeX64PublicationToMavenRepository " +
-                "publishAndroidNativeX86PublicationToMavenRepository",
-            gradleParams = "--parallel -Psigning.gnupg.homeDir=%env.SIGN_KEY_LOCATION%/.gnupg"
-        )
+        // Publish targets in separate steps to avoid implicit dependency between different targets
+        // Issue: https://youtrack.jetbrains.com/issue/KTOR-7556/
+        for (task in ANDROID_NATIVE_PUBLISH_TASKS) {
+            createSonatypeRepository(task)
+            publish(task, gradleParams = "--parallel -Psigning.gnupg.homeDir=%env.SIGN_KEY_LOCATION%/.gnupg")
+        }
     }
     requirements {
         require(linux.agentString, minMemoryMB = 7000)

--- a/.teamcity/src/subprojects/release/space/PublishSpaceBuildsRelease.kt
+++ b/.teamcity/src/subprojects/release/space/PublishSpaceBuildsRelease.kt
@@ -169,12 +169,7 @@ object PublishAndroidNativeToSpaceRelease : BuildType({
     }
     steps {
         releaseToSpace(
-            listOf(
-                "publishAndroidNativeArm64PublicationToMavenRepository",
-                "publishAndroidNativeArm32PublicationToMavenRepository",
-                "publishAndroidNativeX64PublicationToMavenRepository",
-                "publishAndroidNativeX86PublicationToMavenRepository",
-            ),
+            ANDROID_NATIVE_PUBLISH_TASKS,
             gradleParams = "-Psigning.gnupg.homeDir=%env.SIGN_KEY_LOCATION%/.gnupg"
         )
     }


### PR DESCRIPTION
A workaround for [KTOR-7556](https://youtrack.jetbrains.com/issue/KTOR-7556/Implicit-dependency-between-sign-and-publish-tasks-of-different-platforms)