### PR TITLE
Refactor build entries and add missing build configurations

### DIFF
--- a/.teamcity/src/subprojects/Agents.kt
+++ b/.teamcity/src/subprojects/Agents.kt
@@ -18,6 +18,19 @@ object Agents {
     /** 8 CPU, 16 GB RAM */
     const val LARGE = "Large"
 
+    /** Operating Systems available to run builds. */
+    enum class OS(id: String? = null, family: String? = null) {
+        Linux,
+        Windows,
+        MacOS(id = "macOS", family = "Mac OS");
+
+        /** The OS identifier to be used in build ID. */
+        val id: String = id ?: name
+
+        /** The OS family to be used to select the correct agent. */
+        val family: String = family ?: name
+    }
+
     /**
      * CPU architectures available to run builds.
      *
@@ -33,18 +46,18 @@ object Agents {
 }
 
 fun Requirements.agent(
-    os: OSEntry,
+    osEntry: OSEntry,
     hardwareCapacity: String = MEDIUM
 ) {
-    agent(os.family, os.arch, hardwareCapacity)
+    agent(osEntry.os, osEntry.arch, hardwareCapacity)
 }
 
 fun Requirements.agent(
-    os: String?,
+    os: Agents.OS?,
     osArch: Agents.Arch = Agents.Arch.X64,
     hardwareCapacity: String = MEDIUM,
 ) {
-    if (os != null) equals("teamcity.agent.jvm.os.family", os)
+    if (os != null) equals("teamcity.agent.jvm.os.family", os.family)
     equals("teamcity.agent.jvm.os.arch", osArch.agentArch)
 
     // It is better to use memory constraint to select agent as it unlocks the possibility to use more powerful agents

--- a/.teamcity/src/subprojects/Agents.kt
+++ b/.teamcity/src/subprojects/Agents.kt
@@ -3,7 +3,6 @@ package subprojects
 import jetbrains.buildServer.configs.kotlin.*
 import subprojects.Agents.LARGE
 import subprojects.Agents.MEDIUM
-import subprojects.build.*
 
 object Agents {
     /** Use any available agent for the specified OS. */
@@ -45,11 +44,16 @@ object Agents {
     }
 }
 
+interface AgentSpec {
+    val os: Agents.OS
+    val arch: Agents.Arch
+}
+
 fun Requirements.agent(
-    osEntry: OSEntry,
+    spec: AgentSpec,
     hardwareCapacity: String = MEDIUM
 ) {
-    agent(osEntry.os, osEntry.arch, hardwareCapacity)
+    agent(spec.os, spec.arch, hardwareCapacity)
 }
 
 fun Requirements.agent(

--- a/.teamcity/src/subprojects/Agents.kt
+++ b/.teamcity/src/subprojects/Agents.kt
@@ -17,22 +17,35 @@ object Agents {
 
     /** 8 CPU, 16 GB RAM */
     const val LARGE = "Large"
+
+    /**
+     * CPU architectures available to run builds.
+     *
+     * @property agentArch The architecture name as it is specified on agents.
+     */
+    enum class Arch(val agentArch: String) {
+        X64("x86_64"),
+        Arm64("aarch64");
+
+        /** The architecture identifier to be used in build ID. */
+        val id: String = name.lowercase()
+    }
 }
 
 fun Requirements.agent(
     os: OSEntry,
     hardwareCapacity: String = MEDIUM
 ) {
-    agent(os.osFamily, os.osArch, hardwareCapacity)
+    agent(os.family, os.arch, hardwareCapacity)
 }
 
 fun Requirements.agent(
     os: String?,
-    osArch: String? = null,
+    osArch: Agents.Arch = Agents.Arch.X64,
     hardwareCapacity: String = MEDIUM,
 ) {
     if (os != null) equals("teamcity.agent.jvm.os.family", os)
-    if (osArch != null) equals("teamcity.agent.jvm.os.arch", osArch)
+    equals("teamcity.agent.jvm.os.arch", osArch.agentArch)
 
     // It is better to use memory constraint to select agent as it unlocks the possibility to use more powerful agents
     val memorySizeMb = when (hardwareCapacity) {

--- a/.teamcity/src/subprojects/Env.kt
+++ b/.teamcity/src/subprojects/Env.kt
@@ -1,0 +1,9 @@
+package subprojects
+
+import subprojects.build.*
+
+/** Environment variables available on agents. */
+object Env {
+    /** Path to LTS JDK. */
+    val JDK_LTS = "%env.${JDKEntry.JavaLTS.env}%"
+}

--- a/.teamcity/src/subprojects/Triggers.kt
+++ b/.teamcity/src/subprojects/Triggers.kt
@@ -2,7 +2,7 @@ package subprojects
 
 import jetbrains.buildServer.configs.kotlin.*
 import jetbrains.buildServer.configs.kotlin.triggers.*
-import subprojects.build.*
+import subprojects.Agents.OS
 
 /**
  * A set of common branch filters.
@@ -98,23 +98,22 @@ class BuildTarget(sourceSets: List<String>) {
         val JS = BuildTarget("js", "jsAndWasmShared")
         val WasmJS = BuildTarget("wasmJs", "jsAndWasmShared")
 
-        fun Native(osEntry: OSEntry) = BuildTarget(
+        fun Native(os: OS) = BuildTarget(
             listOf("desktop", "posix", "jvmAndPosix") +
-                nixSourceSets(osEntry) +
-                osSourceSets(osEntry)
+                nixSourceSets(os) +
+                osSourceSets(os)
         )
 
         /** Source sets that are built only on a specific OS. */
-        private fun osSourceSets(osEntry: OSEntry): List<String> = when (osEntry) {
-            macOS -> listOf("darwin", "macos", "ios", "tvos", "watchos")
-            linux -> listOf("linux")
-            windows -> listOf("windows", "mingw")
-            else -> emptyList()
+        private fun osSourceSets(os: OS): List<String> = when (os) {
+            OS.MacOS -> listOf("darwin", "macos", "ios", "tvos", "watchos")
+            OS.Linux -> listOf("linux")
+            OS.Windows -> listOf("windows", "mingw")
         }
 
-        private fun nixSourceSets(osEntry: OSEntry): List<String> = when (osEntry) {
-            linux, macOS -> listOf("nix", "jvmAndNix")
-            else -> emptyList()
+        private fun nixSourceSets(os: OS): List<String> = when (os) {
+            OS.Linux, OS.MacOS -> listOf("nix", "jvmAndNix")
+            OS.Windows -> emptyList()
         }
     }
 }

--- a/.teamcity/src/subprojects/benchmarks/ProjectBenchmarks.kt
+++ b/.teamcity/src/subprojects/benchmarks/ProjectBenchmarks.kt
@@ -42,7 +42,7 @@ object ProjectBenchmarks : Project({
         }
 
         requirements {
-            agent(linux)
+            agent(Agents.OS.Linux)
         }
 
         defaultBuildFeatures(VCSCore.id.toString())

--- a/.teamcity/src/subprojects/benchmarks/ProjectBenchmarks.kt
+++ b/.teamcity/src/subprojects/benchmarks/ProjectBenchmarks.kt
@@ -32,12 +32,12 @@ object ProjectBenchmarks : Project({
                 tasks =
                     "publishJvmPublicationToMavenLocal publishKotlinMultiplatformPublicationToMavenLocal -PreleaseVersion=1.0.0-BENCHMARKS"
                 workingDir = "ktor"
-                jdkHome = "%env.${javaLTS.env}%"
+                jdkHome = Env.JDK_LTS
             }
             gradle {
                 tasks = "test -PktorVersion=1.0.0-BENCHMARKS"
                 workingDir = "ktor-benchmarks/allocation-benchmark"
-                jdkHome = "%env.${javaLTS.env}%"
+                jdkHome = Env.JDK_LTS
             }
         }
 

--- a/.teamcity/src/subprojects/build/ProjectBuild.kt
+++ b/.teamcity/src/subprojects/build/ProjectBuild.kt
@@ -33,6 +33,9 @@ data class NativeEntry(
     override val arch: Agents.Arch = Agents.Arch.X64,
 ) : AgentSpec {
 
+    /** The ID to be used as a part of build ID. */
+    val id: String = "${os.id}_${arch.id}"
+
     companion object {
         val MacOS = NativeEntry(
             os = OS.MacOS,
@@ -59,7 +62,10 @@ data class OSJDKEntry(
     override val os: OS,
     val jdkEntry: JDKEntry,
     override val arch: Agents.Arch = Agents.Arch.X64,
-) : AgentSpec
+) : AgentSpec {
+    /** The ID to be used as a part of build ID. */
+    val id: String = "${os.id}${jdkEntry.name}"
+}
 
 const val junitReportArtifact = "+:**/build/reports/** => junitReports.tgz"
 const val memoryReportArtifact = "+:**/hs_err*|+:**/HEAP/* => outOfMemoryDumps.tgz"

--- a/.teamcity/src/subprojects/build/ProjectBuild.kt
+++ b/.teamcity/src/subprojects/build/ProjectBuild.kt
@@ -13,11 +13,11 @@ import subprojects.build.samples.*
 
 data class JDKEntry(val name: String, val env: String)
 data class OSEntry(
-    val name: String,
-    val osFamily: String,
-    val testTaskName: String,
-    val binaryTaskName: String,
-    val osArch: String? = null
+    val family: String,
+    val testTasks: String,
+    val binaryTasks: String,
+    val id: String = family,
+    val arch: Agents.Arch = Agents.Arch.X64,
 )
 
 data class JSEntry(val name: String, val dockerContainer: String)
@@ -27,25 +27,22 @@ const val junitReportArtifact = "+:**/build/reports/** => junitReports.tgz"
 const val memoryReportArtifact = "+:**/hs_err*|+:**/HEAP/* => outOfMemoryDumps.tgz"
 
 val macOS = OSEntry(
-    "macOS",
-    "Mac OS",
-    "cleanMacosX64Test macosX64Test",
-    "linkReleaseExecutableMacosX64",
-    "x86_64"
+    id = "macOS",
+    family = "Mac OS",
+    testTasks = "cleanMacosX64Test macosX64Test",
+    binaryTasks = "linkReleaseExecutableMacosX64",
 )
 
 val linux = OSEntry(
-    "Linux",
-    "Linux",
-    "cleanLinuxX64Test linuxX64Test",
-    "linkReleaseExecutableLinuxX64 linkReleaseExecutableLinuxArm64"
+    family = "Linux",
+    testTasks = "cleanLinuxX64Test linuxX64Test",
+    binaryTasks = "linkReleaseExecutableLinuxX64 linkReleaseExecutableLinuxArm64"
 )
 
 val windows = OSEntry(
-    "Windows",
-    "Windows",
-    "cleanMingwX64Test mingwX64Test",
-    "linkReleaseExecutableMingwX64"
+    family = "Windows",
+    testTasks = "cleanMingwX64Test mingwX64Test",
+    binaryTasks = "linkReleaseExecutableMingwX64",
 )
 
 val operatingSystems = listOf(macOS, linux, windows)

--- a/.teamcity/src/subprojects/build/ProjectBuild.kt
+++ b/.teamcity/src/subprojects/build/ProjectBuild.kt
@@ -13,34 +13,34 @@ import subprojects.build.samples.*
 
 data class JDKEntry(val name: String, val env: String)
 data class OSEntry(
-    val family: String,
+    val os: Agents.OS,
     val testTasks: String,
     val binaryTasks: String,
-    val id: String = family,
     val arch: Agents.Arch = Agents.Arch.X64,
 )
 
 data class JSEntry(val name: String, val dockerContainer: String)
-data class OSJDKEntry(val osEntry: OSEntry, val jdkEntry: JDKEntry)
+data class OSJDKEntry(val osEntry: OSEntry, val jdkEntry: JDKEntry) {
+    val os: Agents.OS get() = osEntry.os
+}
 
 const val junitReportArtifact = "+:**/build/reports/** => junitReports.tgz"
 const val memoryReportArtifact = "+:**/hs_err*|+:**/HEAP/* => outOfMemoryDumps.tgz"
 
 val macOS = OSEntry(
-    id = "macOS",
-    family = "Mac OS",
+    os = Agents.OS.MacOS,
     testTasks = "cleanMacosX64Test macosX64Test",
     binaryTasks = "linkReleaseExecutableMacosX64",
 )
 
 val linux = OSEntry(
-    family = "Linux",
+    os = Agents.OS.Linux,
     testTasks = "cleanLinuxX64Test linuxX64Test",
     binaryTasks = "linkReleaseExecutableLinuxX64 linkReleaseExecutableLinuxArm64"
 )
 
 val windows = OSEntry(
-    family = "Windows",
+    os = Agents.OS.Windows,
     testTasks = "cleanMingwX64Test mingwX64Test",
     binaryTasks = "linkReleaseExecutableMingwX64",
 )

--- a/.teamcity/src/subprojects/build/ProjectBuild.kt
+++ b/.teamcity/src/subprojects/build/ProjectBuild.kt
@@ -66,6 +66,7 @@ const val memoryReportArtifact = "+:**/hs_err*|+:**/HEAP/* => outOfMemoryDumps.t
 
 val osJdks = listOf(
     OSJDKEntry(OS.Linux, JDKEntry.Java8), // Minimal supported version
+    OSJDKEntry(OS.Linux, JDKEntry.Java11), // Minimal supported version for Jakarta modules
     OSJDKEntry(OS.Linux, JDKEntry.Java17), // Version used to build Android projects
     OSJDKEntry(OS.Linux, JDKEntry.JavaLTS), // Latest LTS
 )

--- a/.teamcity/src/subprojects/build/ProjectBuild.kt
+++ b/.teamcity/src/subprojects/build/ProjectBuild.kt
@@ -27,14 +27,17 @@ data class JDKEntry(
     }
 }
 
+/**
+ * @property name The name to be shown as a part of a build name.
+ * @property id The ID to be used as a part of build ID.
+ */
 data class NativeEntry(
     override val os: OS,
     val testTasks: String,
     override val arch: Agents.Arch = Agents.Arch.X64,
+    val id: String = "${os.id}_${arch.id}",
+    val name: String = "Native ${os.id}",
 ) : AgentSpec {
-
-    /** The ID to be used as a part of build ID. */
-    val id: String = "${os.id}_${arch.id}"
 
     companion object {
         val MacOSX64 = NativeEntry(
@@ -58,7 +61,20 @@ data class NativeEntry(
             testTasks = "cleanMingwX64Test mingwX64Test",
         )
 
-        val All = listOf(Linux, MacOSX64, MacOSArm64, Windows)
+        val AndroidNative = NativeEntry(
+            id = "AndroidNativeX64",
+            name = "Android Native",
+            os = OS.Linux,
+            testTasks = "cleanAndroidNativeX64Test androidNativeX64Test",
+        )
+
+        val All = listOf(
+            Linux,
+            MacOSX64,
+            MacOSArm64,
+            Windows,
+            AndroidNative,
+        )
     }
 }
 

--- a/.teamcity/src/subprojects/build/ProjectBuild.kt
+++ b/.teamcity/src/subprojects/build/ProjectBuild.kt
@@ -37,9 +37,15 @@ data class NativeEntry(
     val id: String = "${os.id}_${arch.id}"
 
     companion object {
-        val MacOS = NativeEntry(
+        val MacOSX64 = NativeEntry(
             os = OS.MacOS,
             testTasks = "cleanMacosX64Test macosX64Test",
+        )
+
+        val MacOSArm64 = NativeEntry(
+            os = OS.MacOS,
+            arch = Agents.Arch.Arm64,
+            testTasks = "cleanMacosArm64Test macosArm64Test",
         )
 
         val Linux = NativeEntry(
@@ -52,7 +58,7 @@ data class NativeEntry(
             testTasks = "cleanMingwX64Test mingwX64Test",
         )
 
-        val All = listOf(Linux, MacOS, Windows)
+        val All = listOf(Linux, MacOSX64, MacOSArm64, Windows)
     }
 }
 

--- a/.teamcity/src/subprojects/build/ProjectBuild.kt
+++ b/.teamcity/src/subprojects/build/ProjectBuild.kt
@@ -12,7 +12,20 @@ import subprojects.build.generator.*
 import subprojects.build.plugin.*
 import subprojects.build.samples.*
 
-data class JDKEntry(val name: String, val env: String)
+data class JDKEntry(
+    val version: Int,
+    val name: String = "Java $version",
+    val env: String = "JDK_${version}_0",
+) {
+
+    companion object {
+        val Java8 = JDKEntry(8, env = "JDK_1_8")
+        val Java11 = JDKEntry(11)
+        val Java17 = JDKEntry(17)
+        val Java21 = JDKEntry(21)
+        val JavaLTS = Java21
+    }
+}
 
 data class NativeEntry(
     override val os: OS,
@@ -41,6 +54,7 @@ data class NativeEntry(
 }
 
 data class JSEntry(val name: String, val dockerContainer: String)
+
 data class OSJDKEntry(
     override val os: OS,
     val jdkEntry: JDKEntry,
@@ -50,16 +64,10 @@ data class OSJDKEntry(
 const val junitReportArtifact = "+:**/build/reports/** => junitReports.tgz"
 const val memoryReportArtifact = "+:**/hs_err*|+:**/HEAP/* => outOfMemoryDumps.tgz"
 
-val java8 = JDKEntry("Java 8", "JDK_1_8")
-val java11 = JDKEntry("Java 11", "JDK_11_0")
-val java17 = JDKEntry("Java 17", "JDK_17_0")
-val java21 = JDKEntry("Java 21", "JDK_21_0")
-val javaLTS = java21
-
 val osJdks = listOf(
-    OSJDKEntry(OS.Linux, java8), // Minimal supported version
-    OSJDKEntry(OS.Linux, java17), // Version used to build Android projects
-    OSJDKEntry(OS.Linux, javaLTS), // Latest LTS
+    OSJDKEntry(OS.Linux, JDKEntry.Java8), // Minimal supported version
+    OSJDKEntry(OS.Linux, JDKEntry.Java17), // Version used to build Android projects
+    OSJDKEntry(OS.Linux, JDKEntry.JavaLTS), // Latest LTS
 )
 
 val js = JSEntry("Chrome/Node.js", "stl5/ktor-test-image:latest")
@@ -67,8 +75,8 @@ val js = JSEntry("Chrome/Node.js", "stl5/ktor-test-image:latest")
 val javaScriptEngines = listOf(js)
 
 val stressTests = listOf(
-    OSJDKEntry(OS.Linux, javaLTS),
-    OSJDKEntry(OS.Windows, javaLTS)
+    OSJDKEntry(OS.Linux, JDKEntry.JavaLTS),
+    OSJDKEntry(OS.Windows, JDKEntry.JavaLTS)
 )
 
 object ProjectBuild : Project({

--- a/.teamcity/src/subprojects/build/core/APICheckBuild.kt
+++ b/.teamcity/src/subprojects/build/core/APICheckBuild.kt
@@ -29,6 +29,6 @@ object APICheckBuild : BuildType({
     defaultBuildFeatures(VCSCore.id.toString())
 
     requirements {
-        agent(linux)
+        agent(Agents.OS.Linux)
     }
 })

--- a/.teamcity/src/subprojects/build/core/APICheckBuild.kt
+++ b/.teamcity/src/subprojects/build/core/APICheckBuild.kt
@@ -22,7 +22,7 @@ object APICheckBuild : BuildType({
         gradle {
             name = "API Check"
             tasks = "apiCheck"
-            jdkHome = "%env.${javaLTS.env}%"
+            jdkHome = Env.JDK_LTS
         }
     }
 

--- a/.teamcity/src/subprojects/build/core/CodeStyleVerifyBuild.kt
+++ b/.teamcity/src/subprojects/build/core/CodeStyleVerifyBuild.kt
@@ -58,6 +58,6 @@ object CodeStyleVerify : BuildType({
     defaultBuildFeatures(VCSCore.id.toString())
 
     requirements {
-        agent(linux)
+        agent(Agents.OS.Linux)
     }
 })

--- a/.teamcity/src/subprojects/build/core/CodeStyleVerifyBuild.kt
+++ b/.teamcity/src/subprojects/build/core/CodeStyleVerifyBuild.kt
@@ -22,7 +22,7 @@ object CodeStyleVerify : BuildType({
             name = "Run ktlint"
             tasks = "lintKotlin"
             gradleParams = "-PenableCodeStyle=true"
-            jdkHome = "%env.${javaLTS.env}%"
+            jdkHome = Env.JDK_LTS
         }
     }
 

--- a/.teamcity/src/subprojects/build/core/DependenciesCheckBuild.kt
+++ b/.teamcity/src/subprojects/build/core/DependenciesCheckBuild.kt
@@ -24,6 +24,6 @@ class DependenciesCheckBuild : BuildType({
     defaultBuildFeatures(VCSCore.id.toString())
 
     requirements {
-        agent(linux)
+        agent(Agents.OS.Linux)
     }
 })

--- a/.teamcity/src/subprojects/build/core/DependenciesCheckBuild.kt
+++ b/.teamcity/src/subprojects/build/core/DependenciesCheckBuild.kt
@@ -17,7 +17,7 @@ class DependenciesCheckBuild : BuildType({
         gradle {
             name = "Check Dependencies"
             tasks = "snyk-test"
-            jdkHome = "%env.${javaLTS.env}%"
+            jdkHome = Env.JDK_LTS
         }
     }
 

--- a/.teamcity/src/subprojects/build/core/JDKBuild.kt
+++ b/.teamcity/src/subprojects/build/core/JDKBuild.kt
@@ -10,7 +10,7 @@ class JDKBuild(
     private val osJdkEntry: OSJDKEntry,
     private val addTriggers: Boolean = true,
 ) : BuildType({
-    id("KtorMatrixCore_${osJdkEntry.os.id}${osJdkEntry.jdkEntry.name}".toId())
+    id("KtorMatrixCore_${osJdkEntry.id}".toId())
     name = "${osJdkEntry.jdkEntry.name} on ${osJdkEntry.os.id}"
     val artifactsToPublish = formatArtifacts("+:**/build/**/*.jar")
     artifactRules = formatArtifacts(artifactsToPublish, junitReportArtifact, memoryReportArtifact)

--- a/.teamcity/src/subprojects/build/core/JDKBuild.kt
+++ b/.teamcity/src/subprojects/build/core/JDKBuild.kt
@@ -10,8 +10,8 @@ class JDKBuild(
     private val osJdkEntry: OSJDKEntry,
     private val addTriggers: Boolean = true,
 ) : BuildType({
-    id("KtorMatrixCore_${osJdkEntry.osEntry.name}${osJdkEntry.jdkEntry.name}".toId())
-    name = "${osJdkEntry.jdkEntry.name} on ${osJdkEntry.osEntry.name}"
+    id("KtorMatrixCore_${osJdkEntry.osEntry.id}${osJdkEntry.jdkEntry.name}".toId())
+    name = "${osJdkEntry.jdkEntry.name} on ${osJdkEntry.osEntry.id}"
     val artifactsToPublish = formatArtifacts("+:**/build/**/*.jar")
     artifactRules = formatArtifacts(artifactsToPublish, junitReportArtifact, memoryReportArtifact)
 

--- a/.teamcity/src/subprojects/build/core/JDKBuild.kt
+++ b/.teamcity/src/subprojects/build/core/JDKBuild.kt
@@ -3,15 +3,15 @@ package subprojects.build.core
 import jetbrains.buildServer.configs.kotlin.*
 import jetbrains.buildServer.configs.kotlin.buildSteps.*
 import subprojects.*
+import subprojects.Agents.OS
 import subprojects.build.*
-import subprojects.release.*
 
 class JDKBuild(
     private val osJdkEntry: OSJDKEntry,
     private val addTriggers: Boolean = true,
 ) : BuildType({
-    id("KtorMatrixCore_${osJdkEntry.osEntry.id}${osJdkEntry.jdkEntry.name}".toId())
-    name = "${osJdkEntry.jdkEntry.name} on ${osJdkEntry.osEntry.id}"
+    id("KtorMatrixCore_${osJdkEntry.os.id}${osJdkEntry.jdkEntry.name}".toId())
+    name = "${osJdkEntry.jdkEntry.name} on ${osJdkEntry.os.id}"
     val artifactsToPublish = formatArtifacts("+:**/build/**/*.jar")
     artifactRules = formatArtifacts(artifactsToPublish, junitReportArtifact, memoryReportArtifact)
 
@@ -26,21 +26,21 @@ class JDKBuild(
     }
 
     steps {
-        when (osJdkEntry.osEntry) {
-            windows -> {
+        when (osJdkEntry.os) {
+            OS.Windows -> {
                 script {
                     name = "Obtain Library Dependencies"
                     scriptContent = windowsSoftware
                 }
                 defineTCPPortRange()
             }
-            linux -> {
+            OS.Linux -> {
                 script {
                     name = "Obtain Library Dependencies"
                     scriptContent = linuxSoftware
                 }
             }
-            macOS -> {
+            OS.MacOS -> {
                 script {
                     name = "Obtain Library Dependencies"
                     scriptContent = macSoftware
@@ -58,10 +58,7 @@ class JDKBuild(
     defaultBuildFeatures(VCSCore.id.toString())
 
     requirements {
-        agent(linux)
-    }
-    if (osJdkEntry.osEntry == linux && osJdkEntry.jdkEntry == javaLTS) {
-        jvmBuild = this
+        agent(OS.Linux)
     }
 })
 

--- a/.teamcity/src/subprojects/build/core/JPMSCheckBuild.kt
+++ b/.teamcity/src/subprojects/build/core/JPMSCheckBuild.kt
@@ -21,7 +21,7 @@ object JPMSCheckBuild: BuildType({
         gradle {
             name = "Check JPMS build"
             tasks = ":ktor-java-modules-test:compileJava"
-            jdkHome = "%env.${javaLTS.env}%"
+            jdkHome = Env.JDK_LTS
         }
     }
 

--- a/.teamcity/src/subprojects/build/core/JPMSCheckBuild.kt
+++ b/.teamcity/src/subprojects/build/core/JPMSCheckBuild.kt
@@ -28,6 +28,6 @@ object JPMSCheckBuild: BuildType({
     defaultBuildFeatures(VCSCore.id.toString())
 
     requirements {
-        agent(linux)
+        agent(Agents.OS.Linux)
     }
 })

--- a/.teamcity/src/subprojects/build/core/JavaScriptBuild.kt
+++ b/.teamcity/src/subprojects/build/core/JavaScriptBuild.kt
@@ -4,7 +4,6 @@ import jetbrains.buildServer.configs.kotlin.*
 import jetbrains.buildServer.configs.kotlin.buildSteps.*
 import subprojects.*
 import subprojects.build.*
-import subprojects.release.*
 
 class JavaScriptBuild(private val jsEntry: JSEntry) : BuildType({
     id("KtorMatrixJavaScript_${jsEntry.name}".toId())
@@ -31,10 +30,7 @@ class JavaScriptBuild(private val jsEntry: JSEntry) : BuildType({
     defaultBuildFeatures(VCSCore.id.toString())
 
     requirements {
-        agent(linux)
-    }
-    if (jsEntry == js) {
-        jsBuild = this
+        agent(Agents.OS.Linux)
     }
 })
 

--- a/.teamcity/src/subprojects/build/core/NativeBuild.kt
+++ b/.teamcity/src/subprojects/build/core/NativeBuild.kt
@@ -25,7 +25,7 @@ val macSoftware = """
 """.trimIndent()
 
 class NativeBuild(private val entry: NativeEntry, addTriggers: Boolean = true) : BuildType({
-    id("KtorMatrixNative_${entry.os.id}_${entry.arch.id}".toId())
+    id("KtorMatrixNative_${entry.id}".toId())
     name = "Native on ${entry.os.id} ${entry.arch}"
     val artifactsToPublish = formatArtifacts("+:**/build/**/*.klib", "+:**/build/**/*.exe", "+:**/build/**/*.kexe")
     artifactRules = formatArtifacts(artifactsToPublish, junitReportArtifact, memoryReportArtifact)

--- a/.teamcity/src/subprojects/build/core/NativeBuild.kt
+++ b/.teamcity/src/subprojects/build/core/NativeBuild.kt
@@ -75,7 +75,7 @@ class NativeBuild(private val entry: NativeEntry, addTriggers: Boolean = true) :
         gradle {
             name = "Build and Run Tests"
             tasks = "${entry.testTasks} --info"
-            jdkHome = "%env.JDK_11%"
+            jdkHome = Env.JDK_LTS
         }
     }
 

--- a/.teamcity/src/subprojects/build/core/NativeBuild.kt
+++ b/.teamcity/src/subprojects/build/core/NativeBuild.kt
@@ -25,8 +25,8 @@ val macSoftware = """
 """.trimIndent()
 
 class NativeBuild(private val osEntry: OSEntry, addTriggers: Boolean = true) : BuildType({
-    id("KtorMatrixNative_${osEntry.name}_${osEntry.osArch ?: "x64"}".toId())
-    name = "Native on ${osEntry.name} ${osEntry.osArch ?: "x64"}"
+    id("KtorMatrixNative_${osEntry.id}_${osEntry.arch.id}".toId())
+    name = "Native on ${osEntry.id} ${osEntry.arch}"
     val artifactsToPublish = formatArtifacts("+:**/build/**/*.klib", "+:**/build/**/*.exe", "+:**/build/**/*.kexe")
     artifactRules = formatArtifacts(artifactsToPublish, junitReportArtifact, memoryReportArtifact)
 
@@ -74,7 +74,7 @@ class NativeBuild(private val osEntry: OSEntry, addTriggers: Boolean = true) : B
         }
         gradle {
             name = "Build and Run Tests"
-            tasks = "${osEntry.testTaskName} --info"
+            tasks = "${osEntry.testTasks} --info"
             jdkHome = "%env.JDK_11%"
         }
     }

--- a/.teamcity/src/subprojects/build/core/NativeBuild.kt
+++ b/.teamcity/src/subprojects/build/core/NativeBuild.kt
@@ -26,7 +26,7 @@ val macSoftware = """
 
 class NativeBuild(private val entry: NativeEntry, addTriggers: Boolean = true) : BuildType({
     id("KtorMatrixNative_${entry.id}".toId())
-    name = "Native on ${entry.os.id} ${entry.arch}"
+    name = "${entry.name} ${entry.arch}"
     val artifactsToPublish = formatArtifacts("+:**/build/**/*.klib", "+:**/build/**/*.exe", "+:**/build/**/*.kexe")
     artifactRules = formatArtifacts(artifactsToPublish, junitReportArtifact, memoryReportArtifact)
 

--- a/.teamcity/src/subprojects/build/core/NativeBuild.kt
+++ b/.teamcity/src/subprojects/build/core/NativeBuild.kt
@@ -24,9 +24,9 @@ val macSoftware = """
     brew reinstall libidn2
 """.trimIndent()
 
-class NativeBuild(private val osEntry: OSEntry, addTriggers: Boolean = true) : BuildType({
-    id("KtorMatrixNative_${osEntry.os.id}_${osEntry.arch.id}".toId())
-    name = "Native on ${osEntry.os.id} ${osEntry.arch}"
+class NativeBuild(private val entry: NativeEntry, addTriggers: Boolean = true) : BuildType({
+    id("KtorMatrixNative_${entry.os.id}_${entry.arch.id}".toId())
+    name = "Native on ${entry.os.id} ${entry.arch}"
     val artifactsToPublish = formatArtifacts("+:**/build/**/*.klib", "+:**/build/**/*.exe", "+:**/build/**/*.kexe")
     artifactRules = formatArtifacts(artifactsToPublish, junitReportArtifact, memoryReportArtifact)
 
@@ -36,12 +36,12 @@ class NativeBuild(private val osEntry: OSEntry, addTriggers: Boolean = true) : B
 
     if (addTriggers) {
         triggers {
-            onBuildTargetChanges(BuildTarget.Native(osEntry.os))
+            onBuildTargetChanges(BuildTarget.Native(entry.os))
         }
     }
 
     steps {
-        when (osEntry.os) {
+        when (entry.os) {
             OS.Windows -> {
                 powerShell {
                     name = "Remove git from PATH"
@@ -74,7 +74,7 @@ class NativeBuild(private val osEntry: OSEntry, addTriggers: Boolean = true) : B
         }
         gradle {
             name = "Build and Run Tests"
-            tasks = "${osEntry.testTasks} --info"
+            tasks = "${entry.testTasks} --info"
             jdkHome = "%env.JDK_11%"
         }
     }
@@ -82,6 +82,6 @@ class NativeBuild(private val osEntry: OSEntry, addTriggers: Boolean = true) : B
     defaultBuildFeatures(VCSCore.id.toString())
 
     requirements {
-        agent(osEntry)
+        agent(entry)
     }
 })

--- a/.teamcity/src/subprojects/build/core/ProjectCore.kt
+++ b/.teamcity/src/subprojects/build/core/ProjectCore.kt
@@ -18,7 +18,7 @@ object ProjectCore : Project({
     val apiCheck = APICheckBuild
     val osJdkBuilds = osJdks.map(::JDKBuild)
     // Skip Native Windows build for now, it is not working.
-    val nativeBuilds = (operatingSystems - windows).map(::NativeBuild)
+    val nativeBuilds = (NativeEntry.All - NativeEntry.Windows).map(::NativeBuild)
     val javaScriptBuilds = javaScriptEngines.map(::JavaScriptBuild)
     val wasmJsBuilds = javaScriptEngines.map(::WasmJsBuild)
     val stressTestBuilds = stressTests.map(::StressTestBuild)
@@ -31,8 +31,8 @@ object ProjectCore : Project({
     // Builds to be run manually on demand
     buildType(DependenciesCheckBuild())
     // As soon as native Windows builds are disabled, we give an ability to run build on Windows manually
-    buildType(NativeBuild(windows, addTriggers = false))
-    buildType(JDKBuild(OSJDKEntry(windows, java11), addTriggers = false))
+    buildType(NativeBuild(NativeEntry.Windows, addTriggers = false))
+    buildType(JDKBuild(OSJDKEntry(Agents.OS.Windows, java11), addTriggers = false))
 
     buildType {
         allowExternalStatus = true

--- a/.teamcity/src/subprojects/build/core/ProjectCore.kt
+++ b/.teamcity/src/subprojects/build/core/ProjectCore.kt
@@ -32,7 +32,7 @@ object ProjectCore : Project({
     buildType(DependenciesCheckBuild())
     // As soon as native Windows builds are disabled, we give an ability to run build on Windows manually
     buildType(NativeBuild(NativeEntry.Windows, addTriggers = false))
-    buildType(JDKBuild(OSJDKEntry(Agents.OS.Windows, java11), addTriggers = false))
+    buildType(JDKBuild(OSJDKEntry(Agents.OS.Windows, JDKEntry.Java11), addTriggers = false))
 
     buildType {
         allowExternalStatus = true

--- a/.teamcity/src/subprojects/build/core/StressTestBuild.kt
+++ b/.teamcity/src/subprojects/build/core/StressTestBuild.kt
@@ -7,8 +7,8 @@ import subprojects.*
 import subprojects.build.*
 
 class StressTestBuild(private val osJVMComboEntry: OSJDKEntry) : BuildType({
-    id("KtorMatrixStressTest_${osJVMComboEntry.osEntry.id}${osJVMComboEntry.jdkEntry.name}".toId())
-    name = "Stress Test on ${osJVMComboEntry.osEntry.id} and ${osJVMComboEntry.jdkEntry.name}"
+    id("KtorMatrixStressTest_${osJVMComboEntry.os.id}${osJVMComboEntry.jdkEntry.name}".toId())
+    name = "Stress Test on ${osJVMComboEntry.os.id} and ${osJVMComboEntry.jdkEntry.name}"
     vcs {
         root(VCSCore)
     }

--- a/.teamcity/src/subprojects/build/core/StressTestBuild.kt
+++ b/.teamcity/src/subprojects/build/core/StressTestBuild.kt
@@ -34,6 +34,6 @@ class StressTestBuild(private val osJVMComboEntry: OSJDKEntry) : BuildType({
     defaultBuildFeatures(VCSCore.id.toString())
 
     requirements {
-        agent(osJVMComboEntry.osEntry)
+        agent(osJVMComboEntry)
     }
 })

--- a/.teamcity/src/subprojects/build/core/StressTestBuild.kt
+++ b/.teamcity/src/subprojects/build/core/StressTestBuild.kt
@@ -7,7 +7,7 @@ import subprojects.*
 import subprojects.build.*
 
 class StressTestBuild(private val osJVMComboEntry: OSJDKEntry) : BuildType({
-    id("KtorMatrixStressTest_${osJVMComboEntry.os.id}${osJVMComboEntry.jdkEntry.name}".toId())
+    id("KtorMatrixStressTest_${osJVMComboEntry.id}".toId())
     name = "Stress Test on ${osJVMComboEntry.os.id} and ${osJVMComboEntry.jdkEntry.name}"
     vcs {
         root(VCSCore)

--- a/.teamcity/src/subprojects/build/core/StressTestBuild.kt
+++ b/.teamcity/src/subprojects/build/core/StressTestBuild.kt
@@ -7,8 +7,8 @@ import subprojects.*
 import subprojects.build.*
 
 class StressTestBuild(private val osJVMComboEntry: OSJDKEntry) : BuildType({
-    id("KtorMatrixStressTest_${osJVMComboEntry.osEntry.name}${osJVMComboEntry.jdkEntry.name}".toId())
-    name = "Stress Test on ${osJVMComboEntry.osEntry.name} and ${osJVMComboEntry.jdkEntry.name}"
+    id("KtorMatrixStressTest_${osJVMComboEntry.osEntry.id}${osJVMComboEntry.jdkEntry.name}".toId())
+    name = "Stress Test on ${osJVMComboEntry.osEntry.id} and ${osJVMComboEntry.jdkEntry.name}"
     vcs {
         root(VCSCore)
     }

--- a/.teamcity/src/subprojects/build/core/WasmJsBuild.kt
+++ b/.teamcity/src/subprojects/build/core/WasmJsBuild.kt
@@ -4,7 +4,6 @@ import jetbrains.buildServer.configs.kotlin.*
 import jetbrains.buildServer.configs.kotlin.buildSteps.*
 import subprojects.*
 import subprojects.build.*
-import subprojects.release.*
 
 class WasmJsBuild(private val jsEntry: JSEntry) : BuildType({
     id("KtorMatrixWasmJs_${jsEntry.name}".toId())
@@ -31,9 +30,6 @@ class WasmJsBuild(private val jsEntry: JSEntry) : BuildType({
     defaultBuildFeatures(VCSCore.id.toString())
 
     requirements {
-        agent(linux)
-    }
-    if (jsEntry == js) {
-        wasmJsBuild = this
+        agent(Agents.OS.Linux)
     }
 })

--- a/.teamcity/src/subprojects/cli/ProjectCLI.kt
+++ b/.teamcity/src/subprojects/cli/ProjectCLI.kt
@@ -51,7 +51,7 @@ object ReleaseWinGet: BuildType({
     }
 
     requirements {
-        agent(windows, Agents.ANY)
+        agent(Agents.OS.Windows, hardwareCapacity = Agents.ANY)
     }
 })
 
@@ -97,7 +97,7 @@ object ReleaseBrew: BuildType({
     }
 
     requirements {
-        agent(linux, Agents.ANY)
+        agent(Agents.OS.Linux, hardwareCapacity = Agents.ANY)
     }
 })
 
@@ -256,7 +256,7 @@ EOF
     }
 
     requirements {
-        agent(linux, Agents.ANY)
+        agent(Agents.OS.Linux, hardwareCapacity = Agents.ANY)
     }
 })
 
@@ -298,7 +298,7 @@ object PackMsiInstaller : BuildType({
     }
 
     requirements {
-        agent(windows, Agents.ANY)
+        agent(Agents.OS.Windows, hardwareCapacity = Agents.ANY)
     }
 })
 
@@ -342,7 +342,7 @@ object BuildCLI: BuildType({
     }
 
     requirements {
-        agent(linux, Agents.ANY)
+        agent(Agents.OS.Linux, hardwareCapacity = Agents.ANY)
     }
 
     defaultBuildFeatures(VCSKtorCLI.id.toString())

--- a/.teamcity/src/subprojects/eap/PublishSpaceBuilds.kt
+++ b/.teamcity/src/subprojects/eap/PublishSpaceBuilds.kt
@@ -20,7 +20,7 @@ object PublishCustomTaskToSpace : BuildType({
             name = "Assemble"
             tasks =
                 "%taskList% --i -PeapVersion=%eapVersion% --stacktrace --no-parallel -Porg.gradle.internal.network.retry.max.attempts=100000"
-            jdkHome = "%env.${javaLTS.env}%"
+            jdkHome = Env.JDK_LTS
         }
     }
     params {
@@ -175,7 +175,7 @@ private fun BuildSteps.releaseToSpace(
         name = "Publish"
         tasks =
             "$gradleTasks --i -PeapVersion=%eapVersion% $gradleParams --stacktrace --parallel -Porg.gradle.internal.network.retry.max.attempts=100000"
-        jdkHome = "%env.${javaLTS.env}%"
+        jdkHome = Env.JDK_LTS
         if (optional)
             executionMode = BuildStep.ExecutionMode.ALWAYS
     }

--- a/.teamcity/src/subprojects/eap/PublishSpaceBuilds.kt
+++ b/.teamcity/src/subprojects/eap/PublishSpaceBuilds.kt
@@ -49,7 +49,7 @@ object PublishJvmToSpace : BuildType({
         }
     }
     requirements {
-        agent(linux)
+        agent(Agents.OS.Linux)
     }
 })
 
@@ -70,7 +70,7 @@ object PublishJSToSpace : BuildType({
         }
     }
     requirements {
-        agent(linux)
+        agent(Agents.OS.Linux)
     }
 })
 
@@ -95,7 +95,7 @@ object PublishWindowsNativeToSpace : BuildType({
         }
     }
     requirements {
-        agent(windows)
+        agent(Agents.OS.Windows)
     }
 })
 
@@ -116,7 +116,7 @@ object PublishLinuxNativeToSpace : BuildType({
         }
     }
     requirements {
-        agent(linux)
+        agent(Agents.OS.Linux)
     }
 })
 
@@ -141,7 +141,7 @@ object PublishMacOSNativeToSpace : BuildType({
         }
     }
     requirements {
-        agent(macOS)
+        agent(Agents.OS.MacOS)
     }
 })
 
@@ -162,7 +162,7 @@ object PublishAndroidNativeToSpace : BuildType({
         }
     }
     requirements {
-        agent(linux)
+        agent(Agents.OS.Linux)
     }
 })
 

--- a/.teamcity/src/subprojects/eap/SetBuildNumber.kt
+++ b/.teamcity/src/subprojects/eap/SetBuildNumber.kt
@@ -2,14 +2,13 @@ package subprojects.eap
 
 import jetbrains.buildServer.configs.kotlin.*
 import subprojects.*
-import subprojects.build.*
 
 object SetBuildNumber : BuildType({
     id("SetBuildNumberBuild")
     name = "Set EAP Build Number"
     buildNumberPattern = eapVersion
     requirements {
-        agent(linux, Agents.ANY)
+        agent(Agents.OS.Linux, hardwareCapacity = Agents.ANY)
     }
     vcs {
         root(VCSCoreEAP)

--- a/.teamcity/src/subprojects/kotlinx/html/PublishKotlinxHtml.kt
+++ b/.teamcity/src/subprojects/kotlinx/html/PublishKotlinxHtml.kt
@@ -72,7 +72,7 @@ fun Project.publishKotlinxHtmlJvmToSpace() = buildType {
 
     releaseToSpace(
         "Jvm",
-        linux,
+        Agents.OS.Linux,
         tasks.joinToString(" "),
     )
 }
@@ -80,7 +80,7 @@ fun Project.publishKotlinxHtmlJvmToSpace() = buildType {
 fun Project.publishKotlinxHtmlJsToSpace() = buildType {
     releaseToSpace(
         "Js",
-        linux,
+        Agents.OS.Linux,
         "publishJsPublicationToMavenRepository publishWasmJsPublicationToMavenRepository",
     )
 }
@@ -88,7 +88,7 @@ fun Project.publishKotlinxHtmlJsToSpace() = buildType {
 fun Project.publishKotlinxHtmlMacOsToSpace() = buildType {
     releaseToSpace(
         "NativeMacos",
-        macOS,
+        Agents.OS.MacOS,
         MACOS_PUBLISH_TASKS.joinToString(" "),
         GPG_MACOS_GRADLE_ARGS,
     )
@@ -97,7 +97,7 @@ fun Project.publishKotlinxHtmlMacOsToSpace() = buildType {
 fun Project.publishKotlinxHtmlLinuxToSpace() = buildType {
     releaseToSpace(
         "NativeLinux",
-        linux,
+        Agents.OS.Linux,
         "publishLinuxX64PublicationToMavenRepository publishLinuxArm64PublicationToMavenRepository",
     )
 }
@@ -105,7 +105,7 @@ fun Project.publishKotlinxHtmlLinuxToSpace() = buildType {
 fun Project.publishKotlinxHtmlMingwToSpace() = buildType {
     releaseToSpace(
         "NativeWindows",
-        windows,
+        Agents.OS.Windows,
         "publishMingwX64PublicationToMavenRepository",
         GPG_WINDOWS_GRADLE_ARGS,
     )
@@ -113,7 +113,7 @@ fun Project.publishKotlinxHtmlMingwToSpace() = buildType {
 
 private fun BuildType.releaseToSpace(
     platformName: String,
-    os: OSEntry,
+    os: Agents.OS,
     publishTasks: String,
     gradleParameters: String = GPG_DEFAULT_GRADLE_ARGS,
 ) {
@@ -130,7 +130,7 @@ private fun BuildType.releaseToSpace(
     }
 
     steps {
-        prepareKeyFile(agent)
+        prepareKeyFile(os.name)
 
         gradle {
             name = "Publish"
@@ -141,7 +141,7 @@ private fun BuildType.releaseToSpace(
             jdkHome = "%env.${javaLTS.env}%"
         }
 
-        cleanupKeyFile(agent)
+        cleanupKeyFile(os.name)
     }
 
     requirements {

--- a/.teamcity/src/subprojects/kotlinx/html/PublishKotlinxHtml.kt
+++ b/.teamcity/src/subprojects/kotlinx/html/PublishKotlinxHtml.kt
@@ -72,7 +72,7 @@ fun Project.publishKotlinxHtmlJvmToSpace() = buildType {
 
     releaseToSpace(
         "Jvm",
-        linux.osFamily,
+        linux,
         tasks.joinToString(" "),
     )
 }
@@ -80,7 +80,7 @@ fun Project.publishKotlinxHtmlJvmToSpace() = buildType {
 fun Project.publishKotlinxHtmlJsToSpace() = buildType {
     releaseToSpace(
         "Js",
-        linux.osFamily,
+        linux,
         "publishJsPublicationToMavenRepository publishWasmJsPublicationToMavenRepository",
     )
 }
@@ -88,7 +88,7 @@ fun Project.publishKotlinxHtmlJsToSpace() = buildType {
 fun Project.publishKotlinxHtmlMacOsToSpace() = buildType {
     releaseToSpace(
         "NativeMacos",
-        macOS.osFamily,
+        macOS,
         MACOS_PUBLISH_TASKS.joinToString(" "),
         GPG_MACOS_GRADLE_ARGS,
     )
@@ -97,7 +97,7 @@ fun Project.publishKotlinxHtmlMacOsToSpace() = buildType {
 fun Project.publishKotlinxHtmlLinuxToSpace() = buildType {
     releaseToSpace(
         "NativeLinux",
-        linux.osFamily,
+        linux,
         "publishLinuxX64PublicationToMavenRepository publishLinuxArm64PublicationToMavenRepository",
     )
 }
@@ -105,7 +105,7 @@ fun Project.publishKotlinxHtmlLinuxToSpace() = buildType {
 fun Project.publishKotlinxHtmlMingwToSpace() = buildType {
     releaseToSpace(
         "NativeWindows",
-        windows.osFamily,
+        windows,
         "publishMingwX64PublicationToMavenRepository",
         GPG_WINDOWS_GRADLE_ARGS,
     )
@@ -113,7 +113,7 @@ fun Project.publishKotlinxHtmlMingwToSpace() = buildType {
 
 private fun BuildType.releaseToSpace(
     platformName: String,
-    agent: String,
+    os: OSEntry,
     publishTasks: String,
     gradleParameters: String = GPG_DEFAULT_GRADLE_ARGS,
 ) {
@@ -145,6 +145,6 @@ private fun BuildType.releaseToSpace(
     }
 
     requirements {
-        agent(agent)
+        agent(os)
     }
 }

--- a/.teamcity/src/subprojects/kotlinx/html/PublishKotlinxHtml.kt
+++ b/.teamcity/src/subprojects/kotlinx/html/PublishKotlinxHtml.kt
@@ -138,7 +138,7 @@ private fun BuildType.releaseToSpace(
                     "--i -Prelease -PreleaseVersion=%releaseVersion% --stacktrace --no-parallel " +
                     "-Porg.gradle.internal.network.retry.max.attempts=100000 " +
                     gradleParameters
-            jdkHome = "%env.${javaLTS.env}%"
+            jdkHome = Env.JDK_LTS
         }
 
         cleanupKeyFile(os.name)

--- a/.teamcity/src/subprojects/release/ReleaseBuild.kt
+++ b/.teamcity/src/subprojects/release/ReleaseBuild.kt
@@ -7,12 +7,6 @@ import subprojects.*
 var samplesBuild: BuildType? = null
 var apiBuild: BuildType? = null
 var docSamplesBuild: BuildType? = null
-var jvmBuild: BuildType? = null
-var jsBuild: BuildType? = null
-var wasmJsBuild: BuildType? = null
-var nativeWindowsBuild: BuildType? = null
-var nativeLinuxBuild: BuildType? = null
-var nativeMacOSBuild: BuildType? = null
 var publishAllBuild: BuildType? = null
 var publishAllEAPBuild: BuildType? = null
 

--- a/.teamcity/src/subprojects/release/apidocs/ProjectReleaseAPIDocs.kt
+++ b/.teamcity/src/subprojects/release/apidocs/ProjectReleaseAPIDocs.kt
@@ -3,7 +3,6 @@ package subprojects.release.apidocs
 import jetbrains.buildServer.configs.kotlin.*
 import jetbrains.buildServer.configs.kotlin.buildSteps.*
 import subprojects.*
-import subprojects.build.*
 import subprojects.release.*
 
 object ProjectReleaseAPIDocs : Project({
@@ -42,7 +41,7 @@ object ProjectReleaseAPIDocs : Project({
         }
 
         requirements {
-            agent(macOS)
+            agent(Agents.OS.MacOS)
         }
     }
 })

--- a/.teamcity/src/subprojects/release/publishing/PublishMavenBuilds.kt
+++ b/.teamcity/src/subprojects/release/publishing/PublishMavenBuilds.kt
@@ -181,7 +181,7 @@ fun BuildSteps.publish(
         tasks = "$gradleTasks -PreleaseVersion=$releaseVersion $gradleParams " +
             "${if (parallel) "--parallel" else "--no-parallel"} " +
             "--info --stacktrace -Porg.gradle.internal.network.retry.max.attempts=100000"
-        jdkHome = "%env.${javaLTS.env}%"
+        jdkHome = Env.JDK_LTS
     }
     cleanupKeyFile(os)
 }

--- a/.teamcity/src/subprojects/release/publishing/PublishMavenBuilds.kt
+++ b/.teamcity/src/subprojects/release/publishing/PublishMavenBuilds.kt
@@ -59,7 +59,7 @@ object PublishJvmToMaven : BuildType({
         publish(JVM_AND_COMMON_PUBLISH_TASK)
     }
     requirements {
-        agent(linux)
+        agent(Agents.OS.Linux)
     }
 })
 
@@ -76,7 +76,7 @@ object PublishJSToMaven : BuildType({
         publish(JS_PUBLISH_TASK)
     }
     requirements {
-        agent(linux)
+        agent(Agents.OS.Linux)
     }
 })
 
@@ -98,7 +98,7 @@ object PublishWindowsNativeToMaven : BuildType({
         )
     }
     requirements {
-        agent(windows)
+        agent(Agents.OS.Windows)
     }
 })
 
@@ -115,7 +115,7 @@ object PublishLinuxNativeToMaven : BuildType({
         publish(LINUX_PUBLISH_TASK)
     }
     requirements {
-        agent(linux)
+        agent(Agents.OS.Linux)
     }
 })
 
@@ -136,7 +136,7 @@ object PublishMacOSNativeToMaven : BuildType({
         publish(DARWIN_PUBLISH_TASK, GPG_MACOS_GRADLE_ARGS)
     }
     requirements {
-        agent(macOS)
+        agent(Agents.OS.MacOS)
     }
     failureConditions {
         executionTimeoutMin = 8 * 60
@@ -156,7 +156,7 @@ object PublishAndroidNativeToMaven : BuildType({
         publish(ANDROID_NATIVE_PUBLISH_TASK)
     }
     requirements {
-        agent(linux)
+        agent(Agents.OS.Linux)
     }
 })
 

--- a/.teamcity/src/subprojects/release/space/PublishSpaceBuildsRelease.kt
+++ b/.teamcity/src/subprojects/release/space/PublishSpaceBuildsRelease.kt
@@ -45,7 +45,7 @@ object PublishJvmToSpaceRelease : BuildType({
     }
 
     requirements {
-        agent(linux)
+        agent(Agents.OS.Linux)
     }
 })
 
@@ -62,7 +62,7 @@ object PublishJSToSpaceRelease : BuildType({
     }
 
     requirements {
-        agent(linux)
+        agent(Agents.OS.Linux)
     }
 })
 
@@ -91,7 +91,7 @@ object PublishWindowsNativeToSpaceRelease : BuildType({
         )
     }
     requirements {
-        agent(windows)
+        agent(Agents.OS.Windows)
     }
 })
 
@@ -112,7 +112,7 @@ object PublishLinuxNativeToSpaceRelease : BuildType({
         releaseToSpace(LINUX_PUBLISH_TASK)
     }
     requirements {
-        agent(linux)
+        agent(Agents.OS.Linux)
     }
 })
 
@@ -134,7 +134,7 @@ object PublishMacOSNativeToSpaceRelease : BuildType({
     }
 
     requirements {
-        agent(macOS)
+        agent(Agents.OS.MacOS)
     }
 })
 
@@ -150,7 +150,7 @@ object PublishAndroidNativeToSpaceRelease : BuildType({
         releaseToSpace(ANDROID_NATIVE_PUBLISH_TASK)
     }
     requirements {
-        agent(linux)
+        agent(Agents.OS.Linux)
     }
 })
 

--- a/.teamcity/src/subprojects/release/space/PublishSpaceBuildsRelease.kt
+++ b/.teamcity/src/subprojects/release/space/PublishSpaceBuildsRelease.kt
@@ -21,7 +21,7 @@ object PublishCustomTaskToSpaceRelease : BuildType({
             name = "Assemble"
             tasks =
                 "%taskList% --i -PreleaseVersion=$releaseVersion --stacktrace --no-parallel -Porg.gradle.internal.network.retry.max.attempts=100000 -psigning.gnupg.homedir=%env.SIGN_KEY_LOCATION%/.gnupg"
-            jdkHome = "%env.${javaLTS.env}%"
+            jdkHome = Env.JDK_LTS
         }
     }
     params {
@@ -165,7 +165,7 @@ private fun BuildSteps.releaseToSpace(
         name = "Assemble"
         tasks =
             "$gradleTasks --i -PreleaseVersion=$releaseVersion $gradleParams --stacktrace --no-parallel -Porg.gradle.internal.network.retry.max.attempts=100000"
-        jdkHome = "%env.${javaLTS.env}%"
+        jdkHome = Env.JDK_LTS
         if (optional) executionMode = BuildStep.ExecutionMode.ALWAYS
     }
     cleanupKeyFile(os)


### PR DESCRIPTION
- Refactored so-called "entries" (looking for a better name) to make it easier to add new build configurations.
- Simplified JDK configuration
- Added MacOS Arm64 build configuration ([KTOR-7858](https://youtrack.jetbrains.com/issue/KTOR-7858))
- Added Android Native build configuration ([KTOR-7535](https://youtrack.jetbrains.com/issue/KTOR-7535))
- Added Java 11 tests running (will be needed after https://github.com/ktorio/ktor/pull/4502)