### PR TITLE
KTOR-7833 Rewrite pom for maven-google-appengine-standard sample

### DIFF
--- a/.teamcity/src/subprojects/build/samples/ProjectSamples.kt
+++ b/.teamcity/src/subprojects/build/samples/ProjectSamples.kt
@@ -141,6 +141,7 @@ fun BuildSteps.buildMavenSample(relativeDir: String) {
         name = "Test"
         goals = "test"
         workingDir = relativeDir
+        pomLocation = "$relativeDir/pom.xml"
     }
 }
 


### PR DESCRIPTION
This change is supposed to fix a failing build of the `maven-google-appengine-standard sample` project, [failed build logs](https://ktor.teamcity.com/buildConfiguration/Ktor_KtorSamplesValidate_maven_google_appengine_standard/302694?showLog=302694_839_827&logFilter=debug&logView=flowAware).

As I've mentioned in [KTOR-5764](https://youtrack.jetbrains.com/issue/KTOR-5764/Fix-all-the-time-failing-builds-of-the-samples), build system fails to find a `pom.xml`.

I've carefully read documentation for a [maven runner](https://www.jetbrains.com/help/teamcity/maven.html?Maven#Maven+runner+settings) and a [gradle runner](https://www.jetbrains.com/help/teamcity/gradle.html?Maven#Gradle+Parameters). And it seems like there is some difference in how these runners determine build folder.

The maven runner "path to POM" property should be relative to a working directory, if property is not specified, it defaults to the "pom.xml" value.
It looks like "workingDir" is not taken into account, when runner tries to determine POM location, and it resolves to [<Build_Agent_Home>/work/<VCS_Settings_Hash_Code>/pom.xml](https://www.jetbrains.com/help/teamcity/build-checkout-directory.html?Maven#Checkout+Directory+Location), as we can see similar value in logs of a failed build.
```
23:32:53   [INFO] Scanning for projects...
23:32:53   [ERROR] [ERROR] Some problems were encountered while processing the POMs:
23:32:53   [FATAL] Non-readable POM /mnt/agent/work/da7aea9846cb4451/pom.xml: /mnt/agent/work/da7aea9846cb4451/pom.xml (No such file or directory)
```

Actually in the [MavenBuildStep docs](https://teamcity.jetbrains.com/app/dsl-documentation/buildSteps/maven-build-step/index.html) we can clearly see, when "workingDir" property is specified, the "pomLocation" is also reassigned. So I guess suggested change should fix the build.

@osipxd can we try to trigger CI to build sample projects, using this branch?

[YouTrack ticket](https://youtrack.jetbrains.com/issue/KTOR-7833/Rewrite-pom-for-maven-google-appengine-standard-sample)