### PR TITLE
KTOR-7832 Rewrite client-mpp sample to fix build errors

### DIFF
--- a/.teamcity/src/subprojects/build/samples/ProjectSamples.kt
+++ b/.teamcity/src/subprojects/build/samples/ProjectSamples.kt
@@ -78,7 +78,7 @@ object WebSocketSample: BuildType({
     }
 
     params {
-        param("env.ANDROID_SDK_HOME", "%android-sdk.location%")
+        param("env.ANDROID_HOME", "%android-sdk.location%")
     }
 
     defaultBuildFeatures(sample.vcsRoot.id.toString())
@@ -109,7 +109,7 @@ class SampleProject(sample: SampleProjectSettings) : BuildType({
     }
 
     params {
-        param("env.ANDROID_SDK_HOME", "%android-sdk.location%")
+        param("env.ANDROID_HOME", "%android-sdk.location%")
     }
 
     defaultBuildFeatures(sample.vcsRoot.id.toString())
@@ -147,5 +147,5 @@ fun BuildSteps.buildMavenSample(relativeDir: String) {
 
 fun BuildSteps.acceptAndroidSDKLicense() = script {
     name = "Accept Android SDK license"
-    scriptContent = "yes | JAVA_HOME=%env.JDK_18% %env.ANDROID_SDK_HOME%/tools/bin/sdkmanager --licenses"
+    scriptContent = "yes | JAVA_HOME=%env.JDK_18% %env.ANDROID_HOME%/tools/bin/sdkmanager --licenses"
 }


### PR DESCRIPTION
This change should fix the error, when building client-mpp sample.
```
AndroidLocationsException: ANDROID_SDK_HOME is set to the root of your SDK: /home/teamcity/android-sdk-linux
  ANDROID_SDK_HOME was meant to be the parent path of the preference folder expected by the Android tools.
  It is now deprecated.
  
  To set a custom preference folder location, use ANDROID_USER_HOME.
  
  It should NOT be set to the same directory as the root of your SDK.
  To set a custom SDK location, use ANDROID_HOME.
```

But I believe we will have to update the sample itself, because I was not able to build it locally.
[YouTrack ticket](https://youtrack.jetbrains.com/issue/KTOR-7832/Rewrite-client-mpp-sample-to-fix-build-errors)