### PR TITLE
Don't fail build when only one test task failed on native

### DIFF
--- a/.teamcity/src/subprojects/build/core/NativeBuild.kt
+++ b/.teamcity/src/subprojects/build/core/NativeBuild.kt
@@ -69,7 +69,7 @@ class NativeBuild(private val entry: NativeEntry) : BuildType({
         }
         gradle {
             name = "Build and Run Tests"
-            tasks = "${entry.testTasks} --info"
+            tasks = "${entry.testTasks} --info --continue"
             jdkHome = Env.JDK_LTS
         }
     }


### PR DESCRIPTION
other build targets already have `continue` flag: [WasmJs](https://github.com/ktorio/ktor-build/blob/05a67637072d8b8ad31dd93a70c7f9b023a0306b/.teamcity/src/subprojects/build/core/WasmJsBuild.kt#L23), [JVM](https://github.com/ktorio/ktor-build/blob/05a67637072d8b8ad31dd93a70c7f9b023a0306b/.teamcity/src/subprojects/build/core/JDKBuild.kt#L48), [Js](https://github.com/ktorio/ktor-build/blob/05a67637072d8b8ad31dd93a70c7f9b023a0306b/.teamcity/src/subprojects/build/core/JavaScriptBuild.kt#L23)

[Gradle docs](https://docs.gradle.org/current/userguide/command_line_interface.html#sec:continue_build_on_failure)