### PR TITLE
Install Rust toolchain for Native Builds

### DIFF
--- a/.teamcity/scripts/install_rust_unix.sh
+++ b/.teamcity/scripts/install_rust_unix.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+CARGO_BIN="$HOME/.cargo/bin"
+if ! command -v "$CARGO_BIN/cargo" >/dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+fi
+if [ -f "$HOME/.cargo/env" ]; then
+  . "$HOME/.cargo/env"
+fi
+echo "##teamcity[setParameter name='env.PATH' value='$CARGO_BIN:$PATH']"
+cargo --version

--- a/.teamcity/scripts/install_rust_windows.ps1
+++ b/.teamcity/scripts/install_rust_windows.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+$cargoBin = Join-Path $env:USERPROFILE ".cargo\bin"
+$cargoExe = Join-Path $cargoBin "cargo.exe"
+
+if (-not (Test-Path $cargoExe)) {
+    $rustup = Join-Path $env:TEMP "rustup-init.exe"
+    Invoke-WebRequest -UseBasicParsing -Uri "https://win.rustup.rs/x86_64" -OutFile $rustup
+    & $rustup -y
+}
+
+$newPath = "$cargoBin;$env:PATH"
+Write-Host "##teamcity[setParameter name='env.PATH' value='$newPath']"
+& $cargoExe --version

--- a/.teamcity/src/subprojects/build/core/APICheckBuild.kt
+++ b/.teamcity/src/subprojects/build/core/APICheckBuild.kt
@@ -16,6 +16,11 @@ object APICheckBuild : BuildType({
     }
 
     cancelPreviousBuilds()
+
+    params {
+        param("env.KTOR_RUST_COMPILATION", "true")
+    }
+
     steps {
         gradle {
             name = "API Check"

--- a/.teamcity/src/subprojects/build/core/APICheckBuild.kt
+++ b/.teamcity/src/subprojects/build/core/APICheckBuild.kt
@@ -17,11 +17,11 @@ object APICheckBuild : BuildType({
 
     cancelPreviousBuilds()
 
-    params {
-        param("env.KTOR_RUST_COMPILATION", "true")
-    }
+    enableRustCompilation(os = Agents.OS.Linux)
 
     steps {
+        setupRustAarch64CrossCompilation(os = Agents.OS.Linux)
+
         gradle {
             name = "API Check"
             tasks = "apiCheck"

--- a/.teamcity/src/subprojects/build/core/JDKBuild.kt
+++ b/.teamcity/src/subprojects/build/core/JDKBuild.kt
@@ -20,6 +20,11 @@ class JDKBuild(
     }
 
     cancelPreviousBuilds()
+
+    params {
+        param("env.KTOR_RUST_COMPILATION", "true")
+    }
+
     steps {
         if (osJdkEntry.os == OS.Windows) {
             defineTCPPortRange()

--- a/.teamcity/src/subprojects/build/core/JDKBuild.kt
+++ b/.teamcity/src/subprojects/build/core/JDKBuild.kt
@@ -21,9 +21,7 @@ class JDKBuild(
 
     cancelPreviousBuilds()
 
-    params {
-        param("env.KTOR_RUST_COMPILATION", "true")
-    }
+    enableRustCompilation(osJdkEntry.os)
 
     steps {
         if (osJdkEntry.os == OS.Windows) {

--- a/.teamcity/src/subprojects/build/core/NativeBuild.kt
+++ b/.teamcity/src/subprojects/build/core/NativeBuild.kt
@@ -32,6 +32,19 @@ class NativeBuild(private val entry: NativeEntry) : BuildType({
             }
             defineTCPPortRange()
         }
+
+        if (entry.os == OS.Windows) {
+            powerShell {
+                name = "Install Rust (rustup)"
+                scriptFile("install_rust_windows.ps1")
+            }
+        } else {
+            script {
+                name = "Install Rust (rustup)"
+                scriptFile("install_rust_unix.sh")
+            }
+        }
+
         gradle {
             name = "Build and Run Tests"
             tasks = "${entry.testTasks} --info --continue"

--- a/.teamcity/src/subprojects/build/core/NativeBuild.kt
+++ b/.teamcity/src/subprojects/build/core/NativeBuild.kt
@@ -18,6 +18,11 @@ class NativeBuild(private val entry: NativeEntry) : BuildType({
     }
 
     cancelPreviousBuilds()
+
+    params {
+        param("env.KTOR_RUST_COMPILATION", "true")
+    }
+
     steps {
         if (entry.os == OS.Windows) {
             powerShell {

--- a/.teamcity/src/subprojects/build/core/NativeBuild.kt
+++ b/.teamcity/src/subprojects/build/core/NativeBuild.kt
@@ -19,9 +19,7 @@ class NativeBuild(private val entry: NativeEntry) : BuildType({
 
     cancelPreviousBuilds()
 
-    params {
-        param("env.KTOR_RUST_COMPILATION", "true")
-    }
+    enableRustCompilation(entry.os)
 
     steps {
         if (entry.os == OS.Windows) {
@@ -38,17 +36,7 @@ class NativeBuild(private val entry: NativeEntry) : BuildType({
             defineTCPPortRange()
         }
 
-        if (entry.os == OS.Windows) {
-            powerShell {
-                name = "Install Rust (rustup)"
-                scriptFile("install_rust_windows.ps1")
-            }
-        } else {
-            script {
-                name = "Install Rust (rustup)"
-                scriptFile("install_rust_unix.sh")
-            }
-        }
+        installRust(entry.os)
 
         gradle {
             name = "Build and Run Tests"

--- a/.teamcity/src/subprojects/build/core/RustUtils.kt
+++ b/.teamcity/src/subprojects/build/core/RustUtils.kt
@@ -1,0 +1,51 @@
+package subprojects.build.core
+
+import dsl.scriptFile
+import jetbrains.buildServer.configs.kotlin.BuildSteps
+import jetbrains.buildServer.configs.kotlin.BuildTypeSettings
+import jetbrains.buildServer.configs.kotlin.buildSteps.powerShell
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
+import subprojects.Agents.OS
+
+fun BuildSteps.installRust(os: OS) {
+    if (os == OS.Windows) {
+        powerShell {
+            name = "Install Rust (rustup)"
+            scriptFile("install_rust_windows.ps1")
+        }
+    } else {
+        script {
+            name = "Install Rust (rustup)"
+            scriptFile("install_rust_unix.sh")
+        }
+    }
+}
+
+fun BuildTypeSettings.enableRustCompilation(os: OS) {
+    params {
+        param("env.KTOR_RUST_COMPILATION", "true")
+        if (os == OS.Linux) {
+            param(
+                "env.KTOR_OVERRIDE_KONAN_PROPERTIES",
+                "targetSysRoot.linux_x64=/;libGcc.linux_x64=/usr/lib/gcc/x86_64-linux-gnu/13;linker.linux_x64=/usr/bin/ld.bfd;crtFilesLocation.linux_x64=/usr/lib/x86_64-linux-gnu/"
+            )
+        }
+    }
+}
+
+fun BuildSteps.setupRustAarch64CrossCompilation(os: OS) {
+    require(os == OS.Linux) { "Can be used only on Linux" }
+    script {
+        name = "Setup Rust aarch64 cross compilation"
+        scriptContent = """
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+            
+            rustup target add aarch64-unknown-linux-gnu
+            
+            mkdir -p .cargo
+            echo '[target.aarch64-unknown-linux-gnu]' > .cargo/config.toml
+            echo 'linker = "aarch64-linux-gnu-gcc"' >> .cargo/config.toml
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
Fix the CI issue for `ktor-client-webrtc-rs` with a missing Rust toolchain.

- https://github.com/ktorio/ktor/pull/5044
- It was already tested in TeamCity on [macOS](https://ktor.teamcity.com/buildConfiguration/Ktor_KtorMatrixNativeMacOSX64/358031) (successful) and [Windows](https://ktor.teamcity.com/buildConfiguration/Ktor_KtorMatrixNativeWindowsX64#358035) (this one fails because of some flaky test, not missing `cargo`)

PS: The WasmJS build should be fixed by installing `cargo` directly on the Docker image (https://github.com/e5l/ktor-test-image/pull/4).