### PR TITLE
Remove registry publication from build script

### DIFF
--- a/.teamcity/src/subprojects/build/generator/ProjectGenerator.kt
+++ b/.teamcity/src/subprojects/build/generator/ProjectGenerator.kt
@@ -6,9 +6,9 @@ object ProjectGenerator : Project({
     id("ProjectKtorGenerator")
     name = "Project Generator"
     description = "Code for start.ktor.io"
-    
+
     /**
-     *
+     * Publishes the plugin registry to the Space file repository.
      */
     buildType(PublishPluginRegistry)
 

--- a/.teamcity/src/subprojects/release/ReleaseBuild.kt
+++ b/.teamcity/src/subprojects/release/ReleaseBuild.kt
@@ -3,7 +3,6 @@ package subprojects.release
 import jetbrains.buildServer.configs.kotlin.*
 import jetbrains.buildServer.configs.kotlin.buildFeatures.*
 import subprojects.*
-import subprojects.build.generator.PublishPluginRegistry
 
 var samplesBuild: BuildType? = null
 var apiBuild: BuildType? = null
@@ -63,10 +62,6 @@ object ReleaseBuild : BuildType({
                 snapshot(it) {
                 }
             }
-        }
-        snapshot(PublishPluginRegistry) {
-            onDependencyFailure = FailureAction.IGNORE
-            reuseBuilds = ReuseBuilds.NO
         }
     }
 })


### PR DESCRIPTION
This step has never really made sense in the release build because it assumes that the artifact is available in maven central after we publish it, which it is not.

Our best option for now is to wait for dependabot to open the PR when the ktor artifacts are available.